### PR TITLE
Potential fix for code scanning alert no. 81: File is not always closed

### DIFF
--- a/tests/unit/cli/create/test_credentials.py
+++ b/tests/unit/cli/create/test_credentials.py
@@ -169,7 +169,8 @@ class TestCreateCredentials(unittest.TestCase):
                 ]
                 main()
 
-            data = yaml.safe_load(open(inventory_file))
+            with open(inventory_file) as f:
+                data = yaml.safe_load(f)
             creds = data["applications"]["app_empty_plain"]["credentials"]
             # api_key should exist and be an empty string, not a vault block
             self.assertIn("api_key", creds)


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/81](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/81)

To fix the issue, we should ensure that any file opened is also closed, even if an exception occurs. The best and most Pythonic way to handle this is to use a `with` statement when opening the file. This will ensure the file is closed as soon as the `with` block is exited, regardless of whether an exception is thrown. In this case, replace `yaml.safe_load(open(inventory_file))` with opening the file in a `with` block and passing the file object to `yaml.safe_load()` within that block. The result of the load should be stored in the local variable as before.

Change only the specific lines relating to the file open on line 172 in `tests/unit/cli/create/test_credentials.py`. No other changes to functionality are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
