### PR TITLE
Potential fix for code scanning alert no. 62: Module is imported with 'import' and 'import from'

### DIFF
--- a/tests/unit/module_utils/manager/test_inventory_manager.py
+++ b/tests/unit/module_utils/manager/test_inventory_manager.py
@@ -1,7 +1,7 @@
 import tempfile
 import unittest
 from pathlib import Path
-from unittest import mock
+
 from module_utils.manager.inventory import InventoryManager  # type: ignore
 from module_utils.handler.vault import VaultScalar  # type: ignore
 
@@ -43,11 +43,11 @@ class TestInventoryManager(unittest.TestCase):
                 return {}
 
             with (
-                mock.patch(
+                unittest.mock.patch(
                     "module_utils.manager.inventory.YamlHandler.load_yaml",
                     side_effect=fake_load_yaml,
                 ),
-                mock.patch("module_utils.manager.inventory.VaultHandler"),
+                unittest.mock.patch("module_utils.manager.inventory.VaultHandler"),
             ):
                 with self.assertRaises(SystemExit) as ctx:
                     InventoryManager(


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/62](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/62)

To fix the problem, we should remove the duplicated and confusing import forms for the `unittest` module. Specifically, we should remove `from unittest import mock` on line 4 and ensure that all usages of `mock` in the code are changed to refer to `unittest.mock` instead (e.g., `mock.patch` becomes `unittest.mock.patch`). Since all usages in this snippet are within this file and they all currently use the `mock` name, search for them and update them accordingly. This change is contained only within the file shown: `tests/unit/module_utils/manager/test_inventory_manager.py`.

Steps:
1. Remove the line `from unittest import mock`.
2. Update all uses of `mock` to `unittest.mock` (e.g., change `mock.patch(...)` to `unittest.mock.patch(...)`).

No new imports or custom methods are needed beyond this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
