### PR TITLE
Potential fix for code scanning alert no. 61: Module is imported with 'import' and 'import from'

### DIFF
--- a/tests/unit/cli/deploy/test_dedicated.py
+++ b/tests/unit/cli/deploy/test_dedicated.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 import unittest
 from typing import Any, Dict, List
-from unittest import mock
 import subprocess
 
 from cli.deploy import dedicated as deploy


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/61](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/61)

To fix the issue, we should remove the `from unittest import mock` import statement on line 5. This aligns with the recommendation to avoid importing from the same module using both `import` and `from ... import ...`, thereby making the imports more clear and maintainable. If `mock` is referenced elsewhere in the shown (or unshown) code of this file, it should be referenced as `unittest.mock`. Since the provided code snippet does not show any usage of `mock` directly, removing this import should not break anything in the given code. All `TestCase` usages are done as `unittest.TestCase`, so no further changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
