### PR TITLE
Potential fix for code scanning alert no. 47: Unused local variable

### DIFF
--- a/roles/sys-ctl-cln-bkps/files/script.py
+++ b/roles/sys-ctl-cln-bkps/files/script.py
@@ -37,7 +37,7 @@ def is_directory_used_by_another_process(directory_path):
     process = subprocess.Popen(
         [command], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
     )
-    output, error = process.communicate()
+    output, _ = process.communicate()
     # @See https://stackoverflow.com/questions/29841984/non-zero-exit-code-for-lsof
     if process.wait() > bool(0):
         return False


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/47](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/47)

The best way to fix this problem is to remove the unused assignment to `error` while retaining any side effects from `process.communicate()`. Since both `output` and `error` are returned from a single call, and only `output` is possibly needed in the future, you can assign the second, unused value to `_`, a well-known Python convention to indicate a deliberately unused variable. This will satisfy both CodeQL and readers of the code as being intentional, and eliminates the warning without modifying existing functionality.

To implement this change, update line 40 in roles/sys-ctl-cln-bkps/files/script.py so that `output, error = process.communicate()` becomes `output, _ = process.communicate()`.

No new imports, methods, or further changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
