### PR TITLE
Potential fix for code scanning alert no. 46: Unused local variable

### DIFF
--- a/roles/sys-ctl-cln-bkps/files/script.py
+++ b/roles/sys-ctl-cln-bkps/files/script.py
@@ -37,7 +37,7 @@ def is_directory_used_by_another_process(directory_path):
     process = subprocess.Popen(
         [command], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
     )
-    output, error = process.communicate()
+    process.communicate()
     # @See https://stackoverflow.com/questions/29841984/non-zero-exit-code-for-lsof
     if process.wait() > bool(0):
         return False


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/46](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/46)

To fix the issue, remove the unused assignment to the `output` variable on line 40. You still need to call `process.communicate()` (since it may be required for process completion), but you should unpack only the value(s) you use or, if you don't use any, assign the result to `_` or just call the method without assignment. The best-practice approach in Python when you're obliged to unpack two values but only use one is to assign the unused value to `_` or a clearly unused-name. In this case, neither `output` nor `error` is used, but since the code already calls `process.wait()` (which is redundant after `communicate()`, but that's outside the scope here), we can simply call `process.communicate()` without assigning output values at all. This will remove the unused variable warning, improve code clarity, and retain the process completion.

The change should be made in the function `is_directory_used_by_another_process` inside "roles/sys-ctl-cln-bkps/files/script.py": change `output, error = process.communicate()` to just `process.communicate()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
