### PR TITLE
Potential fix for code scanning alert no. 63: Module is imported with 'import' and 'import from'

### DIFF
--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -1,7 +1,6 @@
 import os
 import tempfile
 import unittest
-from unittest import mock
 import cli.__main__ as main
 
 
@@ -10,7 +9,7 @@ class TestMainHelpers(unittest.TestCase):
     # Existing tests …
     # ----------------------
 
-    @mock.patch("cli.__main__.Style")
+    @unittest.mock.patch("cli.__main__.Style")
     def test_color_text_wraps_text_with_color_and_reset(self, mock_style):
         """
         color_text() should wrap text with the given color prefix and Style.RESET_ALL.
@@ -43,7 +42,7 @@ class TestMainHelpers(unittest.TestCase):
             self.assertIn((None, "rootcmd"), commands)
             self.assertIn(("sub", "innercmd"), commands)
 
-    @mock.patch("cli.__main__.subprocess.run", side_effect=Exception("mocked error"))
+    @unittest.mock.patch("cli.__main__.subprocess.run", side_effect=Exception("mocked error"))
     def test_extract_description_via_help_returns_dash_on_exception(self, mock_run):
         """
         extract_description_via_help() should return '-' if subprocess.run
@@ -52,7 +51,7 @@ class TestMainHelpers(unittest.TestCase):
         result = main.extract_description_via_help("/fake/path/script.py")
         self.assertEqual(result, "-")
 
-    @mock.patch("cli.__main__.subprocess.run")
+    @unittest.mock.patch("cli.__main__.subprocess.run")
     def test_show_full_help_for_all_invokes_help_for_each_command(self, mock_run):
         """
         show_full_help_for_all() should execute a help subprocess call for each
@@ -120,24 +119,24 @@ class TestMainHelpers(unittest.TestCase):
             main.git_clean_repo()
             mock_run.assert_called_once_with(["git", "clean", "-Xfd"], check=True)
 
-    @mock.patch("cli.__main__.subprocess.run")
+    @unittest.mock.patch("cli.__main__.subprocess.run")
     def test_extract_description_via_help_with_description(self, mock_run):
         # Simulate subprocess returning help output with a description
         mock_stdout = "usage: dummy.py [options]\n\nThis is a help description.\n"
-        mock_run.return_value = mock.Mock(stdout=mock_stdout)
+        mock_run.return_value = unittest.mock.Mock(stdout=mock_stdout)
         description = main.extract_description_via_help("/fake/path/dummy.py")
         self.assertEqual(description, "This is a help description.")
 
-    @mock.patch("cli.__main__.subprocess.run")
+    @unittest.mock.patch("cli.__main__.subprocess.run")
     def test_extract_description_via_help_without_description(self, mock_run):
         # Simulate subprocess returning help output without a description
         mock_stdout = "usage: empty.py [options]\n"
-        mock_run.return_value = mock.Mock(stdout=mock_stdout)
+        mock_run.return_value = unittest.mock.Mock(stdout=mock_stdout)
         description = main.extract_description_via_help("/fake/path/empty.py")
         self.assertEqual(description, "-")
 
-    @mock.patch("cli.__main__.extract_description_via_help")
-    @mock.patch("cli.__main__.format_command_help")
+    @unittest.mock.patch("cli.__main__.extract_description_via_help")
+    @unittest.mock.patch("cli.__main__.format_command_help")
     @mock.patch("builtins.print")
     def test_print_global_help_uses_helpers_per_command(
         self, mock_print, mock_fmt, mock_extract


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/63](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/63)

To fix this problem, we should remove the line `from unittest import mock` and instead use `unittest.mock` throughout the test file. In this code, all occurences of `mock.patch` and `mock.Mock` should be replaced with `unittest.mock.patch` and `unittest.mock.Mock`, respectively. This change preserves all functionality, avoids confusion, and complies with best practices that discourage mixing `import xxx` with `from xxx import yyy` for the same module. The only changes required are:

- Remove or comment out line 4: `from unittest import mock`.
- Update all usages of `mock.patch` to `unittest.mock.patch`.
- Update usages of `mock.Mock` to `unittest.mock.Mock`.

No changes to imports other than this are needed, and no new modules need to be installed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
