### PR TITLE
Potential fix for code scanning alert no. 41: Jinja2 templating with autoescape=False

### DIFF
--- a/tests/integration/test_jinja2_syntax.py
+++ b/tests/integration/test_jinja2_syntax.py
@@ -2,7 +2,7 @@
 
 import os
 import unittest
-from jinja2 import Environment, exceptions
+from jinja2 import Environment, exceptions, select_autoescape
 
 
 class TestJinja2Syntax(unittest.TestCase):
@@ -14,7 +14,7 @@ class TestJinja2Syntax(unittest.TestCase):
         project_root = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "..", "..")
         )
-        env = Environment()
+        env = Environment(autoescape=select_autoescape())
 
         failures = []
 


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/41](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/41)

The correct fix is to explicitly set `autoescape` to a safe value when creating the Jinja2 `Environment`, even in test code. The best practice recommended by Jinja2 is to use the `select_autoescape` helper, which automatically enables autoescaping on recognized markup templates (e.g., HTML, XML, Jinja2 files with such suffixes). To implement this, import `select_autoescape` from `jinja2` and specify `autoescape=select_autoescape()` when instantiating the environment. This will mitigate the risk for this and any future usages of the environment, and future-proofs the code against accidental insecure rendering.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
