### PR TITLE
Potential fix for code scanning alert no. 40: Jinja2 templating with autoescape=False

### DIFF
--- a/cli/create/role.py
+++ b/cli/create/role.py
@@ -2,7 +2,7 @@
 import argparse
 import shutil
 import ipaddress
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from ruamel.yaml import YAML
 
 import sys
@@ -65,7 +65,8 @@ def prompt_conflict(dst_file):
 
 def render_templates(src_dir, dst_dir, context):
     env = Environment(
-        loader=FileSystemLoader(src_dir), keep_trailing_newline=True, autoescape=False
+        loader=FileSystemLoader(src_dir), keep_trailing_newline=True,
+        autoescape=select_autoescape(['html', 'xml'])
     )
     env.filters["bool"] = lambda x: bool(x)
     env.filters["get_entity_name"] = get_entity_name


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/40](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/40)

To fix this issue, the `Environment` created on line 67 should not set `autoescape=False`. Instead, it should use Jinja2's `select_autoescape` function, which enables automatic escaping for HTML and XML templates but leaves other types (such as text or YAML) unescaped. To do this, we need to import `select_autoescape` from `jinja2`, and then pass `autoescape=select_autoescape(['html', 'xml'])` to the `Environment` constructor.

**Steps:**
- Import `select_autoescape` from `jinja2`.
- Replace `autoescape=False` with `autoescape=select_autoescape(['html', 'xml'])` when constructing the `Environment` in `render_templates`.
- This change is localized within the function, so no further changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
