### PR TITLE
Potential fix for code scanning alert no. 52: Potentially uninitialized local variable

### DIFF
--- a/tests/integration/test_roles_folder_names.py
+++ b/tests/integration/test_roles_folder_names.py
@@ -16,6 +16,7 @@ class TestRolesFolderNames(unittest.TestCase):
         )
 
         # List all entries in the roles directory
+        entries = []
         try:
             entries = os.listdir(roles_dir)
         except FileNotFoundError:


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/52](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/52)

The best way to fix this problem is to initialize the local variable `entries` before the `try` block. This ensures that `entries` always exists, even if, for some unforeseen reason, the exception is not handled as expected, or if static analysis tools can't prove the control flow. This can be done by adding `entries = []` before the `try`, so that it is always defined. This change should only be made in the region of the code provided, in the function `test_no_underscore_in_role_folder_names` in `tests/integration/test_roles_folder_names.py`. No new methods or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
