### PR TITLE
Potential fix for code scanning alert no. 80: File is not always closed

### DIFF
--- a/tests/unit/cli/create/test_credentials.py
+++ b/tests/unit/cli/create/test_credentials.py
@@ -97,7 +97,8 @@ class TestCreateCredentials(unittest.TestCase):
                 # Should complete without error
                 main()
                 # Verify inventory file updated with vaulted api_key
-                data = yaml.safe_load(open(inventory_file))
+                with open(inventory_file) as f:
+                    data = yaml.safe_load(f)
                 creds = data["applications"]["app_test"]["credentials"]
                 self.assertIn("api_key", creds)
                 # VaultScalar serializes to a vault block, safe_load returns a string containing the vault header


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/80](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/80)

The best way to fix this is to ensure that the file opened at line 100 is always closed, even if an exception occurs while reading with `yaml.safe_load`. The recommended practice is to use a `with` statement that opens the file and passes the open file object to `yaml.safe_load` inside the context. This way, the file is automatically closed when the block exits, preserving the existing functionality, and ensuring that resources are not leaked. Only the immediate block around line 100 in `tests/unit/cli/create/test_credentials.py` needs to be changed; imports and other logic do not require modification.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
