### PR TITLE
Potential fix for code scanning alert no. 79: File is not always closed

### DIFF
--- a/cli/meta/j2/compiler.py
+++ b/cli/meta/j2/compiler.py
@@ -30,15 +30,16 @@ def expand_includes(rel_path, seen=None):
         raise FileNotFoundError(f"Template not found: {rp}")
 
     output_lines = []
-    for line in open(abs_path, encoding="utf-8"):
-        m = INCLUDE_RE.match(line)
-        if not m:
-            output_lines.append(line.rstrip("\n"))
-        else:
-            indent, inc_rel = m.group(1), m.group(2)
-            # rekursiver Aufruf
-            for inc_line in expand_includes(inc_rel, seen):
-                output_lines.append(indent + inc_line)
+    with open(abs_path, encoding="utf-8") as f:
+        for line in f:
+            m = INCLUDE_RE.match(line)
+            if not m:
+                output_lines.append(line.rstrip("\n"))
+            else:
+                indent, inc_rel = m.group(1), m.group(2)
+                # rekursiver Aufruf
+                for inc_line in expand_includes(inc_rel, seen):
+                    output_lines.append(indent + inc_line)
     seen.remove(rp)
     return output_lines
 


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/79](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/79)

The best way to fix this problem is to ensure that the file is always closed, even if an exception is raised while iterating over its lines. This is best achieved by surrounding the file open/read with a `with` statement, which guarantees closure. Specifically, replace `for line in open(abs_path, encoding="utf-8"):` with `with open(abs_path, encoding="utf-8") as f:` followed by `for line in f:`. Only the region of code handling file reading within the `expand_includes` function (lines 33-42) is affected: the context of reading lines from the file needs to be indented beneath the `with` block. No additional methods or packages are required. Only Python builtins are used, so no imports are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
