### PR TITLE
Potential fix for code scanning alert no. 53: Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -482,6 +482,7 @@ def main() -> None:
             print(color_text(f"Exception running command: {e}", Fore.RED))
             failure_with_warning_loop(no_signal, sound_enabled, alarm_timeout)
             sys.exit(1)
+        return None
 
     try:
         if infinite:


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/53](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/53)

To resolve the issue flagged, ensure that `run_once()` always returns a value explicitly, even if that value is just `None`. Since all other paths either terminate the program or raise an exception, an explicit `return None` at the end of the function will clarify that no value is intentionally returned in those paths. Therefore, after the `except` block in `run_once()`, add `return None` before the function ends. This should occur after the existing exception handling but before the function's indented block closes. No new imports or definitions are needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
