### PR TITLE
Potential fix for code scanning alert no. 54: Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/roles/web-app-keycloak/library/keycloak_kcadm_update.py
+++ b/roles/web-app-keycloak/library/keycloak_kcadm_update.py
@@ -135,6 +135,7 @@ def run_kcadm(module, cmd, ignore_rc=False):
         return rc.returncode, stdout, stderr
     except Exception as e:
         module.fail_json(msg="Failed to run kcadm command", cmd=cmd, error=str(e))
+        return None, None, None
 
 
 def deep_merge(a, b):


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/54](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/54)

To address the issue, we should add an explicit `return` statement immediately after the `module.fail_json()` call within the `except` block of `run_kcadm`. The value returned is not actually used (since `fail_json` terminates the program), but returning a value matching the function’s normal output `(rc.returncode, stdout, stderr)` (for example, `None, None, None`) is common for clarity. This ensures all code paths in the function return a consistent value, which aids static analysis and developer readability. No further method, import, or definition changes are needed beyond this minor edit within `run_kcadm`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
