### PR TITLE
Potential fix for code scanning alert no. 56: Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/tests/integration/test_role_dependencies_circular.py
+++ b/tests/integration/test_role_dependencies_circular.py
@@ -48,6 +48,8 @@ def resolve_dependencies(roles_dir):
 
         stack.pop()  # Remove the current role from the stack
 
+        return None
+
     for role_name in os.listdir(roles_dir):
         role_path = os.path.join(roles_dir, role_name)
         if os.path.isdir(role_path):


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/56](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/56)

To fix the problem, we should ensure that all code paths in the `visit` function return a value explicitly. Since the only explicit return in the current function is `return []` (when a role has already been processed), and the rest of the function seems to use exception raising or traversal with no intended resultant value, the cleanest and most consistent fix is to add an explicit `return None` at the end of the function. This makes it clear to readers and static analysis tools that the function always returns a value (either `[]` or `None`). No other changes are necessary, as the return value is not used in the rest of the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
