### PR TITLE
Potential fix for code scanning alert no. 45: Implicit string concatenation in a list

### DIFF
--- a/tests/integration/test_uppercase_constant_vars_unique.py
+++ b/tests/integration/test_uppercase_constant_vars_unique.py
@@ -101,8 +101,8 @@ class TestUppercaseConstantVarsUnique(unittest.TestCase):
 
         if duplicates:
             msg_lines = [
-                "Found TOP-LEVEL constants defined more than once. "
-                "ALL-CAPS top-level variables are treated as constants and must be defined only once project-wide.\n"
+                "Found TOP-LEVEL constants defined more than once. ",
+                "ALL-CAPS top-level variables are treated as constants and must be defined only once project-wide.\n",
                 "Nested ALL-CAPS keys are allowed and ignored by this test.",
                 "",
             ]


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/45](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/45)

To resolve the implicit concatenation and make the developer's intention clear, the three literals in lines 104-106 should be separated by commas. That is, each string should become its own distinct element in the list assigned to `msg_lines`. This ensures that when `"\n".join(msg_lines)` is called, each message appears on its own line, and the overall messaging makes sense. Only line 104–106 in `tests/integration/test_uppercase_constant_vars_unique.py` need fixing, by inserting commas at the end of lines 104 and 105.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
