### PR TITLE
Potential fix for code scanning alert no. 60: Module is imported with 'import' and 'import from'

### DIFF
--- a/tests/unit/cli/create/test_credentials.py
+++ b/tests/unit/cli/create/test_credentials.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import unittest
-from unittest import mock
+
 from cli.create.credentials import ask_for_confirmation, main
 from module_utils.handler.vault import VaultHandler
 import subprocess
@@ -11,11 +11,11 @@ import yaml
 
 class TestCreateCredentials(unittest.TestCase):
     def test_ask_for_confirmation_yes(self):
-        with mock.patch("builtins.input", return_value="y"):
+        with unittest.mock.patch("builtins.input", return_value="y"):
             self.assertTrue(ask_for_confirmation("test_key"))
 
     def test_ask_for_confirmation_no(self):
-        with mock.patch("builtins.input", return_value="n"):
+        with unittest.mock.patch("builtins.input", return_value="n"):
             self.assertFalse(ask_for_confirmation("test_key"))
 
     def test_vault_encrypt_string_success(self):
@@ -25,7 +25,7 @@ class TestCreateCredentials(unittest.TestCase):
         completed = subprocess.CompletedProcess(
             args=["ansible-vault"], returncode=0, stdout=fake_output, stderr=""
         )
-        with mock.patch("subprocess.run", return_value=completed) as proc_run:
+        with unittest.mock.patch("subprocess.run", return_value=completed) as proc_run:
             result = handler.encrypt_string("plain_val", "name")
             proc_run.assert_called_once()
             self.assertEqual(result, fake_output)
@@ -36,7 +36,7 @@ class TestCreateCredentials(unittest.TestCase):
         completed = subprocess.CompletedProcess(
             args=["ansible-vault"], returncode=1, stdout="", stderr="error"
         )
-        with mock.patch("subprocess.run", return_value=completed):
+        with unittest.mock.patch("subprocess.run", return_value=completed):
             with self.assertRaises(RuntimeError):
                 handler.encrypt_string("plain_val", "name")
 


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/60](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/60)

To fix this, we should remove the line `from unittest import mock`. Instead, since we already have `import unittest`, we can access `mock` via `unittest.mock`. In the code, all instances of `mock` (e.g., `mock.patch(...)`) should be updated to use `unittest.mock.patch(...)`. 

All usages of `mock` in the file should be updated accordingly. No other changes are required. No additional imports are needed since `import unittest` already brings in the `mock` submodule.

This involves:
- Removing the line `from unittest import mock`.
- Replacing all occurrences of `mock.` with `unittest.mock.` in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
