### PR TITLE
Potential fix for code scanning alert no. 77: Empty except

### DIFF
--- a/tests/integration/test_variable_definitions.py
+++ b/tests/integration/test_variable_definitions.py
@@ -3,6 +3,7 @@ import os
 import yaml
 import re
 from glob import glob
+import sys
 
 
 class TestVariableDefinitions(unittest.TestCase):
@@ -297,8 +298,8 @@ class TestVariableDefinitions(unittest.TestCase):
                                             f"{path}:{lineno}: bare var '{var}' used but not defined"
                                         )
 
-                except Exception:
-                    pass
+                except Exception as e:
+                    print(f"WARNING: Skipping file due to exception ({path}): {e}", file=sys.stderr)
 
         if undefined_uses:
             self.fail(


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/77](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/77)

The best way to fix this problem is to add logging for the exception or, at a minimum, print a warning message specifying the file that failed and the exception encountered. This maintains robustness (i.e., the test won't crash for one bad file), but increases debuggability and transparency by making it clear when and where a file could not be processed. The fix should be to replace the empty `except Exception: pass` block on lines 300-301 with code that logs or prints the error and includes the path of the file being processed.

A good fix (given this is a test file) is to print a warning to standard error including the filename and exception message. If the `logging` module is available, using it is better, but if not, using `print(..., file=sys.stderr)` is a simple, effective correction. This may require adding `import sys` at the top of the file if not already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
