### PR TITLE
Potential fix for code scanning alert no. 74: Empty except

### DIFF
--- a/tests/integration/test_variable_usage.py
+++ b/tests/integration/test_variable_usage.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import yaml
+import logging
 from glob import glob
 import re
 
@@ -37,8 +38,8 @@ class TestTopLevelVariableUsage(unittest.TestCase):
                 data = yaml.safe_load(f)
                 if isinstance(data, dict):
                     return list(data.keys())
-            except yaml.YAMLError:
-                pass
+            except yaml.YAMLError as e:
+                logging.warning(f"Failed to parse YAML file '%s': %s", file_path, e)
         return []
 
     def find_declaration_line(self, file_path, varname):


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/74](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/74)

The exception block at line 40 should not be empty. The best way to fix this is to log a warning when YAML parsing fails, including the file's path and the error message, before continuing execution (to preserve existing test behavior of skipping files that can't be parsed). Python's built-in `logging` module is generally available and suitable for this purpose. Thus, we should import `logging` at the top of the file and add a log statement in the exception block. This preserves the test's functionality but avoids silent error masking. Only changes needed are: (1) add an import for `logging` and (2) add a logging call in the empty `except` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
