### PR TITLE
Potential fix for code scanning alert no. 73: Empty except

### DIFF
--- a/tests/integration/test_get_app_conf_paths.py
+++ b/tests/integration/test_get_app_conf_paths.py
@@ -207,6 +207,8 @@ class TestGetAppConfPaths(unittest.TestCase):
                         found = True
                         break
                     except AssertionError:
+                        # It's expected that not every config dict will have the required nested keys;
+                        # try the next config dict until found.
                         pass
                 if not found:
                     file_path, lineno = occs[0]


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/73](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/73)

To fix this issue without altering existing functionality, we should add a clear explanatory comment inside the `except AssertionError` block at line 209. The comment should explain that the exception is ignored intentionally because the test iterates over possible locations and this particular location not having the nested key is OK—the search continues elsewhere. No additional imports, classes, or logic are needed; only the comment within the `except` block at line 209 in file `tests/integration/test_get_app_conf_paths.py` needs to be added.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
