### PR TITLE
Potential fix for code scanning alert no. 70: Empty except

### DIFF
--- a/module_utils/sounds.py
+++ b/module_utils/sounds.py
@@ -137,8 +137,8 @@ try:
             finally:
                 try:
                     os.unlink(fname)
-                except Exception:
-                    pass
+                except Exception as e:
+                    warnings.warn(f"Failed to delete temporary sound file {fname}: {e}", RuntimeWarning)
 
         @staticmethod
         def _play(wave: np.ndarray) -> None:


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/70](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/70)

The best way to fix this problem is to avoid silently passing over the exception. Since this is a cleanup in a `finally` block, exceptions from `os.unlink(fname)` should not prevent normal control flow, but they should be visible for debugging. A common solution is to log the exception with a warning. In Python code, the `warnings` module is already imported and used elsewhere in this file, but for errors like failing to delete a temp file, `warnings.warn()` or the `logging` module can be used. Since we are limited to the shown code and cannot assume `logging` is imported, we'll use `warnings.warn()`.

Specifically, in the `finally` block at lines 138–141, replace the `except Exception: pass` with a block that raises a `RuntimeWarning` if the file cannot be deleted, including the exception message for context.

No new imports are needed since `warnings` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
