### PR TITLE
Potential fix for code scanning alert no. 69: Empty except

### DIFF
--- a/module_utils/role_dependency_resolver.py
+++ b/module_utils/role_dependency_resolver.py
@@ -4,7 +4,7 @@ import re
 from typing import Dict, Set, Iterable, Tuple, Optional
 
 import yaml
-
+import logging
 
 class RoleDependencyResolver:
     _RE_PURE_JINJA = re.compile(r"\s*\{\{\s*[^}]+\s*\}\}\s*$")
@@ -233,7 +233,7 @@ class RoleDependencyResolver:
                         if isinstance(r, str) and r.strip():
                             deps.add(r.strip())
         except Exception:
-            pass
+            logging.exception(f"Failed to parse dependencies from {meta_main}")
         return deps
 
     def _extract_meta_run_after(self, role_path: str) -> Set[str]:
@@ -251,7 +251,7 @@ class RoleDependencyResolver:
                     if isinstance(item, str) and item.strip():
                         deps.add(item.strip())
         except Exception:
-            pass
+            logging.exception(f"Failed to parse run_after from {meta_main}")
         return deps
 
     # -------------------------- small utils --------------------------


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/69](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/69)

To fix the empty except block, the best practice is to replace `pass` with a minimal but meaningful handling. The single best way is to **log the exception** with relevant context (e.g., which file caused the error and the error message). This preserves debuggability, but still allows the operation to continue on error, preserving the current "fail-soft" behavior. Python's standard `logging` library should be used for this purpose, as it is a well-known, lightweight dependency.

Specifically, edit the except blocks at line 236 and 254 in `module_utils/role_dependency_resolver.py` replacing `pass` with `logging.exception()` calls that include a descriptive message about the failure to parse the file.  
Add an import for `logging` at the top of the file (among other imports).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
