### PR TITLE
Potential fix for code scanning alert no. 71: Empty except

### DIFF
--- a/tests/integration/test_filters_usage.py
+++ b/tests/integration/test_filters_usage.py
@@ -2,6 +2,7 @@ import ast
 import os
 import re
 import unittest
+import logging
 from typing import Dict, List, Tuple, Optional
 
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
@@ -245,9 +246,10 @@ def search_usage(
             try:
                 if os.path.samefile(path, skip_file):
                     continue
-            except Exception:
-                pass
-
+            except Exception as e:
+                # Exception can occur if files do not exist or are inaccessible.
+                # Skip comparison but log at debug level for diagnosis.
+                logging.debug("Failed to compare files %r and %r: %s", path, skip_file, e)
             content = _read(path)
             if not content:
                 continue


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/71](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/71)

To fix the problem, the empty `except Exception:` block should be replaced with exception handling that (at minimum) gives an explanation for why the exception is being ignored and, preferably, logs the exception for future diagnosis while continuing execution. The current functionality (skipping problematic files) should be preserved.

Most minimally, adding an explanatory comment in the `except` block would satisfy the recommendation, making it clear this is intentional. However, a more robust fix would also log the exception using the `logging` module, which is standard for such debug/investigation output.

Therefore, the best fix is:
- Import the `logging` module at the top of the file (unless already imported).
- In the `except Exception:` block, add a log statement such as `logging.debug("Failed to compare %r and %r: %s", path, skip_file, e)`.
- Add an explanatory comment in the `except` block to clarify why this is considered non-fatal.
The rest of the function should remain unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
