### PR TITLE
Potential fix for code scanning alert no. 72: Empty except

### DIFF
--- a/tests/integration/test_get_app_conf_paths.py
+++ b/tests/integration/test_get_app_conf_paths.py
@@ -199,7 +199,7 @@ class TestGetAppConfPaths(unittest.TestCase):
                         self.assertNested(self.defaults_users, subpath, "default_users")
                         continue
                     except AssertionError:
-                        pass
+                        # It's expected that subpath may not exist in default_users; continue.
                 # application defaults
                 for aid, cfg in self.defaults_app.items():
                     try:


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/72](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/72)

To fix the flagged empty `except` block, we should add a short explanatory comment clarifying that the `AssertionError` is expected when the `subpath` does not exist in `self.defaults_users`, and that the code should silently continue to the next check. This makes the intention behind swallowing the error clear to future readers and static analyzers, and is sufficient to resolve the CodeQL warning. No code logic needs to change; only a comment needs to be added, and all edits should be confined to the shown snippet.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
