### PR TITLE
Potential fix for code scanning alert no. 66: Empty except

### DIFF
--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -6,6 +6,7 @@ import sys
 import textwrap
 import threading
 from datetime import datetime
+import traceback
 import pty
 from module_utils.sounds import Sound
 import time
@@ -288,8 +289,11 @@ def _play_in_child(method_name: str) -> bool:
                     f"[sound] child '{method_name}' exitcode={p.exitcode}", Fore.YELLOW
                 )
             )
-        except Exception:
-            pass
+        except Exception as e:
+            # Failed to print warning about sound child process;
+            # log the exception to stderr for debugging purposes.
+            print(f"Error while attempting to print sound process warning: {e}", file=sys.stderr)
+            traceback.print_exc()
     return p.exitcode == 0
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/66](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/66)

To fix the problem, we should not silently suppress the exception. The recommended approach is to log the exception, or if logging is not available, print an informative message to stderr—ideally including the exception details, so that failures in the error-reporting code don't go unnoticed. If there is a compelling reason to suppress the exception, an explicit explanatory comment should be added.

In this specific context (line 291 of `cli/__main__.py`), we are handling an exception that occurs when printing a warning about a failed child process. Printing may fail due to a variety of reasons (bad output stream, missing colorama, etc). To address this:

- Replace the `except Exception: pass` block.
- Instead, print a message to `sys.stderr` describing the error and log the exception detail (e.g., using `traceback.print_exc()` if available).
- Import `traceback` at the top if it's not already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
