### PR TITLE
Potential fix for code scanning alert no. 43: Unnecessary lambda

### DIFF
--- a/cli/create/role.py
+++ b/cli/create/role.py
@@ -69,7 +69,7 @@ def render_templates(src_dir, dst_dir, context):
         keep_trailing_newline=True,
         autoescape=select_autoescape(["html", "xml"]),
     )
-    env.filters["bool"] = lambda x: bool(x)
+    env.filters["bool"] = bool
     env.filters["get_entity_name"] = get_entity_name
 
     for root, _, files in os.walk(src_dir):


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/43](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/43)

To resolve the unnecessary lambda, replace `env.filters["bool"] = lambda x: bool(x)` with `env.filters["bool"] = bool` in the `render_templates` function. This change has no functional impact, as both versions assign a unary callable for the filter, but it makes the code cleaner and idiomatic. Only the relevant line in `cli/create/role.py` needs to be updated; no new imports or additional logic are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
