### PR TITLE
Potential fix for code scanning alert no. 55: Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/roles/web-app-keycloak/library/keycloak_kcadm_update.py
+++ b/roles/web-app-keycloak/library/keycloak_kcadm_update.py
@@ -226,7 +226,7 @@ def get_current_object(module, object_kind, api, object_id, realm, kcadm_exec):
         module.fail_json(
             msg="Failed to parse current Keycloak object JSON", error=str(e), stdout=out
         )
-
+        return None
 
 def send_update(module, object_kind, api, object_id, realm, kcadm_exec, payload):
     payload_json = json.dumps(payload)


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/55](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/55)

To fix the issue, you should ensure that every possible code path in the `get_current_object` function ends with an explicit return statement. After calling `module.fail_json(...)` in the exception handler, add an explicit `return None` (or just `return`), even though it will never be reached, to satisfy both static analysis tools and human readers that the function always returns an explicit value. No further imports or changes are needed; just a single line in the appropriate location.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
