### PR TITLE
Potential fix for code scanning alert no. 117: Use of a print statement at module level

### DIFF
--- a/cli/fix/move_unnecessary_dependencies/__main__.py
+++ b/cli/fix/move_unnecessary_dependencies/__main__.py
@@ -31,6 +31,7 @@ import re
 import shutil
 import sys
 from typing import Dict, Set, List, Tuple, Optional
+import logging
 
 # --- Require ruamel.yaml for full round-trip preservation ---
 try:
@@ -43,9 +44,8 @@ except Exception:
     _HAVE_RUAMEL = False
 
 if not _HAVE_RUAMEL:
-    print(
-        "[ERR] ruamel.yaml is required to preserve comments/quotes. Install with: pip install ruamel.yaml",
-        file=sys.stderr,
+    logging.error(
+        "ruamel.yaml is required to preserve comments/quotes. Install with: pip install ruamel.yaml"
     )
     sys.exit(3)
 


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/117](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/117)

In general, to fix this issue we should ensure that diagnostic messages are not printed at import time. For library-like modules, dependency checks that may emit output or exit the process should be performed lazily (e.g., inside `main()` or other functions) and use the `logging` or `warnings` modules instead of `print`.

For this specific file, the minimal fix that does not alter functional behavior is to replace the module-level `print` call on lines 46–49 with a `logging.error` call, while still keeping the immediate `sys.exit(3)` to enforce the hard requirement on `ruamel.yaml`. This keeps the early-failure semantics intact but uses the recommended logging mechanism instead of direct printing. To do this, we need to import the `logging` module near the top of the file, alongside the existing imports, and then change the `print(...)` call to `logging.error(...)` with the same message and `file=sys.stderr` removed (logging handles the stream). No other logic needs to change, and we do not need to add a `__main__` guard because the behavior (exit if ruamel is missing) appears intentional for this CLI.

Concretely:
- In `cli/fix/move_unnecessary_dependencies/__main__.py`, add `import logging` after the other standard-library imports.
- Replace the `print(` block under `if not _HAVE_RUAMEL:` with a single `logging.error(...)` call containing the same message, followed by the existing `sys.exit(3)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
