### PR TITLE
Potential fix for code scanning alert no. 121: Empty except

### DIFF
--- a/cli/create/inventory/cli.py
+++ b/cli/create/inventory/cli.py
@@ -4,6 +4,7 @@ import argparse
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+import sys
 
 from .project import detect_project_root, build_env_with_project_root
 from .yaml_io import load_yaml, dump_yaml
@@ -181,7 +182,10 @@ def main(argv: Optional[List[str]] = None) -> int:
             try:
                 vault_password_file.chmod(0o600)
             except PermissionError:
-                pass
+                print(
+                    f"[WARN] Could not set permissions to 0o600 on {vault_password_file}.",
+                    file=sys.stderr,
+                )
         else:
             print(f"[INFO] Using existing vault password file: {vault_password_file}")
 


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/121](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/121)

In general, empty `except` blocks should either (a) perform some clear handling (logging, cleanup, fallback behavior) or (b) be documented with a comment explaining why the exception is intentionally ignored. For a security-related operation like setting file permissions, the safest approach is to at least log a warning when the operation fails.

The best fix here without changing existing functionality is to keep the program’s behavior non-fatal (i.e., don’t raise), but add a small informational or warning message in the `except PermissionError:` block. This preserves the current tolerance of permission errors while making the situation visible and addressing the static analysis concern. We do not need extra imports; we can simply print to stderr using `print(..., file=sys.stderr)` and import `sys` at the top of the file. All changes are confined to `cli/create/inventory/cli.py` in the shown region: (1) add `import sys` alongside the other imports, and (2) replace the `except PermissionError: pass` block with an `except` that prints a warning mentioning the file path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
