### PR TITLE
Potential fix for code scanning alert no. 120: Empty except

### DIFF
--- a/cli/core/sounds.py
+++ b/cli/core/sounds.py
@@ -15,6 +15,7 @@ def init_multiprocessing() -> None:
         if get_start_method(allow_none=True) != "spawn":
             set_start_method("spawn", force=True)
     except RuntimeError:
+        # The start method can only be set once per interpreter; ignore if it was set elsewhere.
         pass
 
     # Prefer system audio backend by default (prevents simpleaudio segfaults in child processes)


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/120](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/120)

To fix this, we should preserve the current behavior (i.e., not treat a `RuntimeError` from `set_start_method` as fatal) but make the empty `except` block intentional and self‑documenting. The most minimal, behavior‑preserving change is to replace `pass` with a short explanatory comment, or a no‑op that includes a comment. Since we must not alter functionality, we should not raise, reconfigure anything else, or log to stderr in a way that might surprise existing users during initialization.

Concretely, in `cli/core/sounds.py`, inside `init_multiprocessing`, change lines 14–18 so that the `except RuntimeError:` block contains an explanatory comment (e.g., noting that a `RuntimeError` is raised when the start method is already set) instead of a bare `pass`. This satisfies the static analysis rule and makes the intent clear, without requiring any new imports or extra definitions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
