### PR TITLE
Potential fix for code scanning alert no. 125: Use of the return value of a procedure

### DIFF
--- a/cli/meta/categories/invokable/__main__.py
+++ b/cli/meta/categories/invokable/__main__.py
@@ -3,4 +3,5 @@ from __future__ import annotations
 from .command import main
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    main()
+    raise SystemExit(0)


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/125](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/125)

In general, to fix this issue you should stop using the return value of a procedure (a function that always returns `None`) and instead just call it for its side effects. Any code that relies on its return value should either ignore it or explicitly use `None` (or a constant) where needed.

Here, the best fix without changing functionality is to separate calling `main()` from exiting the process. Instead of `raise SystemExit(main())`, we call `main()` for its side effects and then exit with a constant success status code (0). This preserves behavior because `SystemExit(None)` and `SystemExit(0)` are equivalent in Python, and CodeQL’s complaint about using the meaningless return value is resolved.

Concretely, in `cli/meta/categories/invokable/__main__.py`, replace line 6 with two statements: first call `main()`, then `raise SystemExit(0)`. No imports or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
