### PR TITLE
Potential fix for code scanning alert no. 136: Empty except

### DIFF
--- a/tests/unit/roles/sys-ctl-bkp-docker-2-loc/library/test_file_has_content.py
+++ b/tests/unit/roles/sys-ctl-bkp-docker-2-loc/library/test_file_has_content.py
@@ -117,6 +117,7 @@ class TestFileHasContentModule(unittest.TestCase):
         try:
             os.remove(missing)
         except FileNotFoundError:
+            # If the file is already absent, that's the state this test requires.
             pass
 
         payload = self._run_expect_fail(missing)


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/136](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/136)

In general, empty `except` blocks should either (1) perform some handling (logging, recovery, re-raising, assertions) or (2) include a clear comment explaining why it is safe and intentional to ignore that specific exception. For this test, we want to keep treating a missing file as a non-error, so the best minimal fix is to keep the `pass` but add an explanatory comment that documents that we deliberately ignore `FileNotFoundError` because the test only needs to guarantee the file is absent.

Concretely, in `tests/unit/roles/sys-ctl-bkp-docker-2-loc/library/test_file_has_content.py`, within `test_missing_file_fails`, modify the `except FileNotFoundError:` block around lines 117–121 so that it contains a short comment above the `pass`, such as “File is already absent; that's fine for this test.” No imports or additional functions are needed, and this preserves all existing behavior while satisfying CodeQL’s requirement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
