### PR TITLE
Potential fix for code scanning alert no. 174: Jinja2 templating with autoescape=False

### DIFF
--- a/tests/unit/lookup_plugins/test_docker_cards.py
+++ b/tests/unit/lookup_plugins/test_docker_cards.py
@@ -5,7 +5,7 @@ import shutil
 import unittest
 
 from ansible.errors import AnsibleError
-from jinja2 import Environment, StrictUndefined
+from jinja2 import Environment, StrictUndefined, select_autoescape
 
 
 # Adjust the PYTHONPATH to include the lookup_plugins folder from the web-app-desktop role.
@@ -49,7 +49,7 @@ class DummyTemplar:
 
     def __init__(self, variables):
         self._vars = variables
-        self._env = Environment(undefined=StrictUndefined)
+        self._env = Environment(undefined=StrictUndefined, autoescape=select_autoescape())
         self._env.filters["bool"] = _ansible_bool
 
     def template(self, value):


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/174](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/174)

In general, the problem is that a `jinja2.Environment` is instantiated without specifying `autoescape`, which defaults to `False`, potentially allowing unescaped HTML or XML content to pass through. The recommended secure pattern is to use `select_autoescape` so that autoescaping is enabled for HTML/XML templates while remaining off for others, or explicitly set `autoescape=True` if you always want escaping.

In this specific file, the best minimal fix that preserves behavior is to configure the environment with `autoescape=select_autoescape()` (or for common HTML/XML types) and to import `select_autoescape` from `jinja2`. Since the tests appear to deal with templated strings (not full template files), using `select_autoescape()` provides safe defaults without tightly coupling to particular extensions, and for non-HTML-looking output this primarily ensures escaping when relevant. Concretely:
- On the import line, extend `from jinja2 import Environment, StrictUndefined` to also import `select_autoescape`.
- In `DummyTemplar.__init__`, change `_env = Environment(undefined=StrictUndefined)` to `_env = Environment(undefined=StrictUndefined, autoescape=select_autoescape())`.

No other changes are needed; filters and rendering logic remain the same.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
