### PR TITLE
Potential fix for code scanning alert no. 173: Code injection

### DIFF
--- a/.github/workflows/test-deploy-workstation.yml
+++ b/.github/workflows/test-deploy-workstation.yml
@@ -77,11 +77,13 @@ jobs:
 
       - name: Deploy app
         shell: bash
+        env:
+          APP: ${{ matrix.app }}
         run: |
           set -euo pipefail
           export TEST_DEPLOY_TYPE="workstation"
           export DISTROS="${DISTROS}"
-          export APP="${{ matrix.app }}"
+          export APP="${APP}"
           make ci-deploy-app
 
       - name: Show last 200 log lines on failure


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/173](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/173)

General approach: Avoid using `${{ matrix.app }}` directly inside the `run:` script. Instead, assign `matrix.app` to an environment variable at the step level using workflow expression syntax, and then reference that value inside the script using normal shell variable expansion (`$APP`) without `${{ ... }}`. This prevents a malicious value from being interpreted as part of the script itself.

Concrete fix for this workflow:

- Modify the "Deploy app" step in the `workstation` job.
- Add an `env:` section to that step to bind `APP` from `${{ matrix.app }}` at the workflow level.
- In the `run:` block, stop using `${{ matrix.app }}` entirely and instead reference `$APP`.
- The existing `export APP="..."` line can either be removed or changed to use the already-set `$APP` without any GitHub expression. To keep behavior nearly identical while still eliminating the injection vector, we will re-export `APP` using the shell variable (which now comes from the `env:` mapping) and no longer interpolate `${{ matrix.app }}` inside the script.

Changes needed (lines approximate):

- Around lines 78–85:
  - Add:

    ```yaml
    env:
      APP: ${{ matrix.app }}
    ```

  - Replace:

    ```yaml
    export APP="${{ matrix.app }}"
    ```

    with:

    ```bash
    export APP="${APP}"
    ```

No additional methods or imports are required; this is a pure YAML/workflow change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
