### PR TITLE
Potential fix for code scanning alert no. 201: Module is imported with 'import' and 'import from'

### DIFF
--- a/tests/unit/module_utils/test_domain_mapper.py
+++ b/tests/unit/module_utils/test_domain_mapper.py
@@ -64,33 +64,48 @@ class TestDomainMapper(unittest.TestCase):
 
     def test_iter_app_domains_empty_on_invalid_structure(self):
         self.assertEqual(
-            list(_domain_mapper.iter_app_domains(self.applications["web-app-no-server"])), []
+            list(
+                _domain_mapper.iter_app_domains(self.applications["web-app-no-server"])
+            ),
+            [],
         )
         self.assertEqual(
-            list(_domain_mapper.iter_app_domains(self.applications["web-app-server-not-dict"])), []
+            list(
+                _domain_mapper.iter_app_domains(
+                    self.applications["web-app-server-not-dict"]
+                )
+            ),
+            [],
         )
         self.assertEqual(
-            list(_domain_mapper.iter_app_domains(self.applications["web-app-domains-not-dict"])), []
+            list(
+                _domain_mapper.iter_app_domains(
+                    self.applications["web-app-domains-not-dict"]
+                )
+            ),
+            [],
         )
 
     def test_iter_app_domains_flattens_all_supported_shapes(self):
         # web-app-a: list + list
-        got_a = list(iter_app_domains(self.applications["web-app-a"]))
+        got_a = list(_domain_mapper.iter_app_domains(self.applications["web-app-a"]))
         self.assertEqual(
             got_a,
             ["a.example", "www.a.example", "A.ALIAS.EXAMPLE"],
         )
 
         # web-app-b: canonical str + aliases []
-        got_b = list(iter_app_domains(self.applications["web-app-b"]))
+        got_b = list(_domain_mapper.iter_app_domains(self.applications["web-app-b"]))
         self.assertEqual(got_b, ["b.example"])
 
         # web-app-c: canonical dict + aliases dict
-        got_c = list(iter_app_domains(self.applications["web-app-c"]))
+        got_c = list(_domain_mapper.iter_app_domains(self.applications["web-app-c"]))
         self.assertEqual(got_c, ["c.example", "api.c.example", "www.c.example"])
 
         # web-app-nested: nested list/dict combinations
-        got_nested = list(iter_app_domains(self.applications["web-app-nested"]))
+        got_nested = list(
+            _domain_mapper.iter_app_domains(self.applications["web-app-nested"])
+        )
         self.assertEqual(
             got_nested,
             [
@@ -104,7 +119,7 @@ class TestDomainMapper(unittest.TestCase):
         )
 
     def test_build_domain_index_case_insensitive(self):
-        idx = build_domain_index(self.applications)
+        idx = _domain_mapper.build_domain_index(self.applications)
 
         # Ensure normalized keys exist
         self.assertEqual(idx["a.example"], "web-app-a")
@@ -142,26 +157,43 @@ class TestDomainMapper(unittest.TestCase):
 
     def test_resolve_app_id_for_domain_found(self):
         self.assertEqual(
-            _domain_mapper.resolve_app_id_for_domain(self.applications, "a.example"), "web-app-a"
+            _domain_mapper.resolve_app_id_for_domain(self.applications, "a.example"),
+            "web-app-a",
         )
         self.assertEqual(
-            _domain_mapper.resolve_app_id_for_domain(self.applications, "WWW.A.EXAMPLE"), "web-app-a"
+            _domain_mapper.resolve_app_id_for_domain(
+                self.applications, "WWW.A.EXAMPLE"
+            ),
+            "web-app-a",
         )
         self.assertEqual(
-            _domain_mapper.resolve_app_id_for_domain(self.applications, "api.c.example"), "web-app-c"
+            _domain_mapper.resolve_app_id_for_domain(
+                self.applications, "api.c.example"
+            ),
+            "web-app-c",
         )
         self.assertEqual(
-            _domain_mapper.resolve_app_id_for_domain(self.applications, "DEEP.NESTED.EXAMPLE"),
+            _domain_mapper.resolve_app_id_for_domain(
+                self.applications, "DEEP.NESTED.EXAMPLE"
+            ),
             "web-app-nested",
         )
 
     def test_resolve_app_id_for_domain_not_found_or_empty(self):
         self.assertIsNone(
-            _domain_mapper.resolve_app_id_for_domain(self.applications, "missing.example")
+            _domain_mapper.resolve_app_id_for_domain(
+                self.applications, "missing.example"
+            )
         )
-        self.assertIsNone(_domain_mapper.resolve_app_id_for_domain(self.applications, ""))
-        self.assertIsNone(_domain_mapper.resolve_app_id_for_domain(self.applications, "   "))
-        self.assertIsNone(_domain_mapper.resolve_app_id_for_domain(self.applications, None))  # type: ignore[arg-type]
+        self.assertIsNone(
+            _domain_mapper.resolve_app_id_for_domain(self.applications, "")
+        )
+        self.assertIsNone(
+            _domain_mapper.resolve_app_id_for_domain(self.applications, "   ")
+        )
+        self.assertIsNone(
+            _domain_mapper.resolve_app_id_for_domain(self.applications, None)  # type: ignore[arg-type]
+        )
 
     def test_resolve_app_id_for_domain_raises_on_collision(self):
         apps = {


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/201](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/201)

To fix this, we should avoid importing `module_utils.domain_mapper` both as a module and via `from ... import` in the same file. The simplest change that preserves all behavior is to keep the plain module import (needed for the `sys.modules.setdefault(...)` hack) and remove the `from module_utils.domain_mapper import (...)` line, then update all uses of the imported functions to reference them via the `_domain_mapper` module object.

Concretely in `tests/unit/module_utils/test_domain_mapper.py`:

- Remove the `from module_utils.domain_mapper import (iter_app_domains, build_domain_index, resolve_app_id_for_domain)` block (lines 6–10 in the snippet).
- Keep `import module_utils.domain_mapper as _domain_mapper`.
- Replace every direct call to `iter_app_domains`, `build_domain_index`, and `resolve_app_id_for_domain` with `_domain_mapper.iter_app_domains`, `_domain_mapper.build_domain_index`, and `_domain_mapper.resolve_app_id_for_domain` respectively in the test methods.
- No new methods or imports are required; the existing `_domain_mapper` import already provides access to the needed functions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
