### PR TITLE
Potential fix for code scanning alert no. 210: Statement has no effect

### DIFF
--- a/cli/mirror/providers.py
+++ b/cli/mirror/providers.py
@@ -10,13 +10,16 @@ from .model import ImageRef
 
 class RegistryProvider(ABC):
     @abstractmethod
-    def image_base(self, image: ImageRef) -> str: ...
+    def image_base(self, image: ImageRef) -> str:
+        pass
 
     @abstractmethod
-    def mirror(self, image: ImageRef) -> None: ...
+    def mirror(self, image: ImageRef) -> None:
+        pass
 
     @abstractmethod
-    def tag_exists(self, image: ImageRef) -> bool: ...
+    def tag_exists(self, image: ImageRef) -> bool:
+        pass
 
 
 class GHCRProvider(RegistryProvider):


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/210](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/210)

In general, to fix “statement has no effect” issues, you either remove the useless expression or replace it with an appropriate operation that reflects the intended behavior (e.g., `pass` for a deliberate no-op, or a real side-effect like logging or raising an exception). For abstract methods, the clearest body is often either `pass` or `raise NotImplementedError()`.

Here, the best minimal-impact fix is to replace each abstract method body that currently contains `...` with `pass`. This preserves the class’s behavior because the `ABC` metaclass and `@abstractmethod` decorators already prevent direct instantiation of `RegistryProvider`. Using `pass` also eliminates the “statement has no effect” warning while making the intent (no implementation in the base class) explicit.

Concretely:
- In `cli/mirror/providers.py`, within `class RegistryProvider`, change the bodies of `image_base`, `mirror`, and `tag_exists` from `...` to `pass`.
- No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
