### PR TITLE
Potential fix for code scanning alert no. 209: Statement has no effect

### DIFF
--- a/cli/mirror/providers.py
+++ b/cli/mirror/providers.py
@@ -10,13 +10,16 @@ from .model import ImageRef
 
 class RegistryProvider(ABC):
     @abstractmethod
-    def image_base(self, image: ImageRef) -> str: ...
+    def image_base(self, image: ImageRef) -> str:
+        pass
 
     @abstractmethod
-    def mirror(self, image: ImageRef) -> None: ...
+    def mirror(self, image: ImageRef) -> None:
+        pass
 
     @abstractmethod
-    def tag_exists(self, image: ImageRef) -> bool: ...
+    def tag_exists(self, image: ImageRef) -> bool:
+        pass
 
 
 class GHCRProvider(RegistryProvider):


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/209](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/209)

In general, to fix “statement has no effect” issues, remove or replace bare expressions that do nothing with either a no-op (`pass`) or with the intended functional code (e.g., call a function, assign to a variable). For abstract methods in Python, the conventional and analyzer-friendly approach is to use `pass` as the method body (optionally with a docstring) when no implementation is provided, relying on `@abstractmethod` to enforce overriding.

For this file, the best minimal change is to replace the `...` expression bodies of the three abstract methods in `RegistryProvider` with `pass`. This keeps semantics exactly the same: the methods remain abstract due to `@abstractmethod`, and they still provide no implementation. No imports or additional definitions are needed; we simply edit lines 13, 16, and 19 in `cli/mirror/providers.py` to use `pass` instead of `...`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
