### PR TITLE
Potential fix for code scanning alert no. 202: Empty except

### DIFF
--- a/module_utils/templating.py
+++ b/module_utils/templating.py
@@ -278,18 +278,21 @@ def _templar_render_best_effort(templar: Any, s: str, variables: dict) -> str:
         ):
             try:
                 templar.available_variables = prev_avail
-            except Exception:
+            except AttributeError:
+                # Best-effort cleanup: ignore if attribute cannot be restored
                 pass
 
         if disable_changed_2:
             try:
                 setattr(templar, "_disable_lookups", prev_disable_2)
-            except Exception:
+            except AttributeError:
+                # Best-effort cleanup: ignore if attribute cannot be restored
                 pass
         if disable_changed_1:
             try:
                 setattr(templar, "disable_lookups", prev_disable_1)
-            except Exception:
+            except AttributeError:
+                # Best-effort cleanup: ignore if attribute cannot be restored
                 pass
 
     out_s = "" if out is None else str(out)


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/202](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/202)

In general, an empty `except` should either be removed, narrowed to specific expected exception types, or augmented with at least logging or a comment documenting why it is safe to ignore. The goal is to avoid silently swallowing unexpected errors while still allowing deliberate “best-effort” cleanup.

For this function, the intent is clearly to attempt to restore `templar.available_variables` and the lookup flags without letting failures in that restoration break the main templating operation. To keep existing functionality, we should still suppress expected cleanup failures, but we can (a) narrow the exception type to `AttributeError` (the most reasonable failure when setting attributes), and (b) add a short explanatory comment that this is best-effort cleanup intentionally ignoring such errors. This way, programming errors that raise other exception types will still propagate, while benign attribute issues are ignored as before.

Concretely, in `module_utils/templating.py` within `_templar_render_best_effort`, update the three `except Exception:` blocks:
- At line 281 around `templar.available_variables = prev_avail`.
- At line 287 around `setattr(templar, "_disable_lookups", prev_disable_2)`.
- At line 292 around `setattr(templar, "disable_lookups", prev_disable_1)`.

For each, change `except Exception:` to `except AttributeError:` and add a short inline or preceding comment such as `# Best-effort cleanup; ignore if attribute is missing or read-only`. No new imports are needed, and no other behavior changes are introduced.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
