### PR TITLE
Potential fix for code scanning alert no. 192: Statement has no effect

### DIFF
--- a/cli/mirror/providers.py
+++ b/cli/mirror/providers.py
@@ -10,13 +10,16 @@ from .model import ImageRef
 
 class RegistryProvider(ABC):
     @abstractmethod
-    def image_base(self, image: ImageRef) -> str: ...
+    def image_base(self, image: ImageRef) -> str:
+        pass
 
     @abstractmethod
-    def mirror(self, image: ImageRef) -> None: ...
+    def mirror(self, image: ImageRef) -> None:
+        pass
 
     @abstractmethod
-    def tag_exists(self, image: ImageRef) -> bool: ...
+    def tag_exists(self, image: ImageRef) -> bool:
+        pass
 
 
 class GHCRProvider(RegistryProvider):


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/192](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/192)

In general, to fix a “statement has no effect” issue for an abstract method, replace the no-op expression (`...`) with either `pass` or an explicit `raise NotImplementedError()` so the intent is clear and the analyzer no longer flags it. For abstract methods in an `ABC`, `pass` is usually sufficient because `@abstractmethod` already prevents instantiation without an override.

For this specific file, we should update each abstract method in `RegistryProvider` whose body is currently `...` to use `pass` instead. This does not alter any runtime behavior: these methods are abstract, have no implementation, and are not supposed to be called directly. Changing `...` to `pass` simply replaces a no-op expression statement with a no-op statement, removing the CodeQL warning and making the code clearer. No new imports, helpers, or signatures are needed. The changes are confined to the three abstract methods `image_base`, `mirror`, and `tag_exists` in `cli/mirror/providers.py` around lines 11–19.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
