### PR TITLE
Potential fix for code scanning alert no. 189: Empty except

### DIFF
--- a/cli/deploy/development/proc.py
+++ b/cli/deploy/development/proc.py
@@ -24,8 +24,9 @@ def _drain_stream(
     finally:
         try:
             stream.close()
-        except Exception:
-            pass
+        except Exception as exc:
+            sys.stderr.write(f"Warning: failed to close stream {stream!r}: {exc}\n")
+            sys.stderr.flush()
 
 
 def run_streaming(


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/189](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/189)

In general, to fix an empty `except` you either (a) handle the error (e.g., log it, perform fallback logic, or release resources differently) or (b) explicitly document why it is safe to ignore it. Here, we are in a cleanup section closing a stream. The safest low-impact fix is to keep swallowing the exception so we don’t change control flow, but record the error for debugging.

The best targeted fix: in `_drain_stream`, change the `except Exception: pass` to capture the exception as `exc` and write a short diagnostic to `sys.stderr` (or use `print(..., file=sys.stderr)`), possibly including the exception’s type and message. This keeps the function’s external behavior (no raised error) while avoiding a completely silent failure. We will not add new imports; `sys` is already imported and sufficient.

Concretely, in `cli/deploy/development/proc.py`, modify lines 25–28 so that:

- `except Exception:` becomes `except Exception as exc:`.
- Replace `pass` with a short stderr message such as `sys.stderr.write(...)` and `sys.stderr.flush()`.

No new methods or definitions are required; we only use existing imports and objects.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
