### PR TITLE
Potential fix for code scanning alert no. 183: Cyclic import

### DIFF
--- a/cli/deploy/development/down.py
+++ b/cli/deploy/development/down.py
@@ -6,7 +6,11 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from .common import repo_root_from_here
+
+def _repo_root_from_here() -> Path:
+    # Derive the repository root relative to this file.
+    # Adjust the number of parents if the project layout changes.
+    return Path(__file__).resolve().parents[3]
 
 
 CI_DOCKER_ROOT = Path("/mnt/docker")
@@ -79,5 +83,5 @@ def add_parser(sub: argparse._SubParsersAction) -> None:
 
 
 def handler(args: argparse.Namespace) -> int:
-    down_stack(repo_root=repo_root_from_here(), distro=args.distro)
+    down_stack(repo_root=_repo_root_from_here(), distro=args.distro)
     return 0


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/183](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/183)

To break the cycle, we should remove the import of `repo_root_from_here` from `common` and avoid calling it at import time from `down.py`. The simplest way, without changing functionality, is to inline an equivalent implementation of `repo_root_from_here` in this file (or a minimal `repo_root_from_here` helper) and have `handler` use that, so `down.py` no longer depends on `common.py`.

Concretely, in `cli/deploy/development/down.py`:

1. Remove the line `from .common import repo_root_from_here`.
2. Add a small, local helper that provides the repository root. Since we can’t see the original, a safe approximation is: start from this file’s directory and go up a fixed number of levels to reach the repo root. For example:
   ```py
   def _repo_root_from_here() -> Path:
       return Path(__file__).resolve().parents[3]
   ```
   This uses only `Path` (already imported) and `__file__`.
3. Update `handler` to call `_repo_root_from_here()` instead of `repo_root_from_here()`.

This fully removes the `common` import, thereby breaking the cycle, while preserving the behavior that `down_stack` runs with a repo-root path derived from the current file’s location.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
