### PR TITLE
Potential fix for code scanning alert no. 182: Cyclic import

### DIFF
--- a/cli/deploy/development/deps.py
+++ b/cli/deploy/development/deps.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from .compose import Compose
 
 
 def resolve_run_after(compose: Compose, role_name: str) -> list[str]:


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/182](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/182)

In general, to fix a cyclic import caused by type references, you avoid importing the type at runtime and instead use forward references: either plain strings for type names or imports inside a `typing.TYPE_CHECKING` block. Because this file already uses `from __future__ import annotations`, annotations are automatically stored as strings and evaluated lazily, so we can safely remove the runtime import of `Compose` while still annotating the parameter as `Compose`.

The best minimal fix here is to delete the line `from .compose import Compose` in `cli/deploy/development/deps.py` and keep the function signature `def resolve_run_after(compose: Compose, ...)` as-is. With `from __future__ import annotations` present, `Compose` will be treated as a string annotation and does not need to exist at import time. This breaks the cycle because `deps.py` no longer imports `compose.py` at runtime, while preserving typing information for type checkers. No other code in the snippet needs to change, and the existing functionality of `resolve_run_after` and `apps_with_deps` remains identical.

Concretely:
- In `cli/deploy/development/deps.py`, remove line 3 containing `from .compose import Compose`.
- Leave the rest of the file unchanged; the `Compose` annotation will be interpreted as a forward reference due to the existing `from __future__ import annotations` line at the top.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
