### PR TITLE
Potential fix for code scanning alert no. 181: Cyclic import

### DIFF
--- a/cli/deploy/development/compose.py
+++ b/cli/deploy/development/compose.py
@@ -139,9 +139,11 @@ class Compose:
                 raise RuntimeError(f"entry.sh init failed (rc={r.returncode})")
 
     def down(self) -> None:
-        from .down import down_stack
-
-        down_stack(repo_root=self.repo_root, distro=self.distro)
+        """
+        Tear down the infinito docker compose stack for this repo/distro.
+        """
+        # Delegate directly to docker compose to avoid importing cli.deploy.development.down
+        self.run(["down"], check=True, capture=False, live=True)
 
     def exec(
         self,


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/181](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/181)

In general, cyclic imports are best fixed by isolating shared or cross-cutting functionality into a third module that both original modules can depend on, instead of depending on each other. Alternatively, if only one function needs access to the other module, that function can be moved into that other module, thereby eliminating the import.

Here, `Compose.down()` only uses `down_stack` from `.down`. The minimal way to break the cycle, without altering behavior, is to invert the dependency: instead of `Compose` calling `down_stack(self.repo_root, self.distro)`, we can move the actual logic from `down_stack` into a new method on `Compose` (e.g., `_down_stack_impl`) and have the `down_stack` function in `down.py` call into `Compose.down()` (or into the new method) rather than the other way around. However, we are not allowed to edit `down.py` in this task. Within `compose.py` alone, the cleanest cycle-breaking change we can make is to remove the import-on-demand pattern and instead defer the "down stack" operation to an external command that does not involve importing `.down`. 

To keep behavior as close as possible while breaking the import cycle from this file, we can replace the `from .down import down_stack` call with a direct subprocess call that runs `docker compose down` (or equivalent) using the same environment and root directory as other methods in `Compose`. This keeps the observable effect—taking the stack down—while avoiding the circular Python-level import. Concretely, in `cli/deploy/development/compose.py`, we will replace the body of `down()` (lines 141–144) so that it uses `self.run([...])` (or `subprocess.run`) to execute the appropriate compose command, and remove the `from .down import down_stack` import. No new imports are strictly necessary, because we already have `subprocess` and internal helpers available.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
