### PR TITLE
Potential fix for code scanning alert no. 180: Cyclic import

### DIFF
--- a/cli/deploy/development/common.py
+++ b/cli/deploy/development/common.py
@@ -4,7 +4,6 @@ import os
 from pathlib import Path
 
 from .compose import Compose
-from .deps import apps_with_deps, resolve_run_after
 
 
 def repo_root_from_here() -> Path:
@@ -23,5 +22,7 @@ def make_compose(*, distro: str) -> Compose:
 
 
 def resolve_deploy_ids_for_app(compose: Compose, app_id: str) -> list[str]:
+    from .deps import apps_with_deps, resolve_run_after
+
     deps = resolve_run_after(compose, app_id)
     return apps_with_deps(app_id, deps_role_names=deps)


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/180](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/180)

In general, to fix a cyclic import, you remove or reorder imports so that the modules no longer depend on each other in a cycle. Options include: moving the small piece of logic that needs the import into the other module, deferring the import inside a function (so it only occurs at call time and not at module import), or extracting shared logic into a third module that both depend on. The goal is to prevent both modules from needing each other at import time.

Here, the only use of `.deps` is inside `resolve_deploy_ids_for_app`, which calls `resolve_run_after` and `apps_with_deps`. We can break the cycle by turning the top-level import of `.deps` into a local, runtime import inside that function. This keeps existing behavior intact but ensures that `cli.deploy.development.deps` is only imported when `resolve_deploy_ids_for_app` is actually called, after all modules are loaded, which removes the problematic *import-time* cycle.

Concretely, in `cli/deploy/development/common.py`:

- Remove `from .deps import apps_with_deps, resolve_run_after` from the module-level imports.
- Inside `resolve_deploy_ids_for_app`, add a local import: `from .deps import apps_with_deps, resolve_run_after` at the beginning of the function body (after the signature).  
  This way, any other code in `common.py` no longer triggers import of `.deps` during module initialization, but the function still behaves exactly the same when called.

No new methods or external libraries are needed. We only adjust where the existing import is performed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
