### PR TITLE
Potential fix for code scanning alert no. 179: Cyclic import

### DIFF
--- a/cli/deploy/development/common.py
+++ b/cli/deploy/development/common.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from .compose import Compose
 from .deps import apps_with_deps, resolve_run_after
 
 
@@ -17,11 +16,13 @@ def ensure_distro_env(distro: str) -> None:
     os.environ["INFINITO_DISTRO"] = distro
 
 
-def make_compose(*, distro: str) -> Compose:
+def make_compose(*, distro: str) -> "Compose":
+    from .compose import Compose
+
     ensure_distro_env(distro)
     return Compose(repo_root=repo_root_from_here(), distro=distro)
 
 
-def resolve_deploy_ids_for_app(compose: Compose, app_id: str) -> list[str]:
+def resolve_deploy_ids_for_app(compose: "Compose", app_id: str) -> list[str]:
     deps = resolve_run_after(compose, app_id)
     return apps_with_deps(app_id, deps_role_names=deps)


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/179](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/179)

In general, to fix Python cyclic imports when one module only needs a type or a small piece of functionality, you can (1) move shared pieces into a third module, (2) restructure code so imports are one-directional, or (3) use lazy/local imports or type-only imports so that the cycle is not triggered at module import time.

Here, the simplest and least invasive fix is to avoid importing `Compose` at module top-level. `common.py` uses `Compose` only in type information and as a constructor target inside `make_compose`. We can break the cycle by:
- Removing the top-level `from .compose import Compose`.
- Adding `from __future__ import annotations` is already present, so type hints are stored as strings and do not need the class at import time.
- Importing `Compose` locally inside `make_compose` (and optionally inside `resolve_deploy_ids_for_app` if desired), so the import happens only when those functions are called, after module initialization, which breaks the cycle during import.

Concretely:
- In `cli/deploy/development/common.py`, delete line 6 (`from .compose import Compose`).
- Change the `make_compose` signature to use a string annotation `'Compose'` instead of the directly-referenced class; `from __future__ import annotations` already makes runtime behavior safe, but using a string keeps the code self-contained if that future import were ever removed.
- Add a local import `from .compose import Compose` at the top of `make_compose`.
- Optionally, do the same for `resolve_deploy_ids_for_app`, or leave it using the string annotation only (no runtime use of `Compose` there).

No other files or imports need modification; we only adjust this file to use a lazy import.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
