### PR TITLE
Potential fix for code scanning alert no. 169: Empty except

### DIFF
--- a/cli/core/run.py
+++ b/cli/core/run.py
@@ -34,6 +34,7 @@ def open_log_file(log_dir: Path) -> tuple[TextIO, Path]:
     try:
         os.chmod(log_dir, 0o700)
     except Exception:
+        # Intentionally ignore chmod failures: non-critical hardening step
         pass
 
     timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/169](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/169)

To fix this, we should keep the behavior of ignoring `os.chmod` failures but make it explicit within the `except` block that this is intentional. The lowest-impact change is to replace `pass` with a comment explaining why exceptions are ignored (or add that comment alongside `pass`). This doesn’t change functionality, avoids new dependencies, and addresses the static analysis finding.

Concretely, in `cli/core/run.py` within `open_log_file`, lines 33–37, update the `except Exception:` block so it contains an explanatory comment such as `# Best-effort: ignore chmod failures (e.g., non-POSIX or restricted FS)` rather than being empty. No new methods or imports are needed; we only adjust this block’s content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
