### PR TITLE
Potential fix for code scanning alert no. 203: Empty except

### DIFF
--- a/module_utils/templating.py
+++ b/module_utils/templating.py
@@ -279,17 +279,23 @@ def _templar_render_best_effort(templar: Any, s: str, variables: dict) -> str:
             try:
                 templar.available_variables = prev_avail
             except Exception:
+                # Best-effort cleanup: failure to restore available_variables should not
+                # break templating; ignore any error during this rollback.
                 pass
 
         if disable_changed_2:
             try:
                 setattr(templar, "_disable_lookups", prev_disable_2)
             except Exception:
+                # Best-effort cleanup: ignore errors while restoring _disable_lookups
+                # to avoid raising from cleanup code.
                 pass
         if disable_changed_1:
             try:
                 setattr(templar, "disable_lookups", prev_disable_1)
             except Exception:
+                # Best-effort cleanup: ignore errors while restoring disable_lookups
+                # to avoid raising from cleanup code.
                 pass
 
     out_s = "" if out is None else str(out)


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/203](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/203)

In general, empty `except` blocks should either be removed (allowing exceptions to propagate), narrowed to specific expected exceptions, or at least log/report the exception so it is not silently discarded. When exceptions are intentionally ignored (e.g., in defensive cleanup), this intent should be documented and, ideally, logged.

For this specific code, we must preserve the existing behavior: exceptions raised while restoring `templar.available_variables` or `_disable_lookups` / `disable_lookups` should *not* propagate and must not change the templating result. The safest fix is therefore:

- Replace each `except Exception: pass` with `except Exception as e:` that:
  - Optionally logs or records a warning using an available mechanism, while
  - Not re-raising the exception, so control flow remains the same.

Since the snippet already imports `AnsibleError` but doesn’t show a logger, and we are told not to modify imports except via well-known libraries, a low-impact approach is to add inline comments explaining why the exception is ignored and to bind the exception (`as exc`) so the `except` block is not *literally* empty. To satisfy “does nothing but pass” and improve debuggability without adding new dependencies or changing behavior, we can:

- Replace `except Exception:` with `except Exception as exc:  # best-effort cleanup; ignore failures`
- Keep a `pass` in the body to preserve behavior; the bound variable and comment clarify intent and may satisfy the rule depending on configuration. To be safer and more helpful in debugging, we can include a no-op reference like `str(exc)` purely to indicate consideration of the exception without side effects. However, to truly add value, adding a comment is usually sufficient in this context per the rule description (“and there is no explanatory comment”).

Concretely in `module_utils/templating.py`:

- Around line 279–282: document that failing to restore `available_variables` is intentionally ignored.
- Around line 285–288 and 290–293: document that failures when restoring lookup-disabling flags are intentionally ignored.

No new imports or helper methods are needed for this documentation-only fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
