### PR TITLE
Potential fix for code scanning alert no. 196: Jinja2 templating with autoescape=False

### DIFF
--- a/module_utils/jinja_strict.py
+++ b/module_utils/jinja_strict.py
@@ -57,10 +57,13 @@ def build_render_context(variables: Dict[str, Any]) -> Tuple[dict, str]:
 
 def _jinja_env():
     try:
-        from jinja2 import Environment, StrictUndefined
+        from jinja2 import Environment, StrictUndefined, select_autoescape
     except Exception as exc:
         raise AnsibleError(f"jinja_strict: cannot import jinja2. Error: {exc}") from exc
-    return Environment(undefined=StrictUndefined)
+    return Environment(
+        undefined=StrictUndefined,
+        autoescape=select_autoescape(["html", "xml"]),
+    )
 
 
 def render_jinja2_strict_once(


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/196](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/196)

In general, the problem is that the Jinja2 `Environment` is created without specifying `autoescape`, which leaves it at the insecure default (`False`). The recommended fix is to explicitly configure `autoescape` using Jinja2’s `select_autoescape` helper so that templates with HTML- or XML-like filenames get automatic escaping, while others retain unescaped behavior.

The best targeted fix here is to modify `_jinja_env` to (1) import `select_autoescape` along with `Environment` and `StrictUndefined`, and (2) construct the `Environment` with `autoescape=select_autoescape(["html", "xml"])`. This keeps the existing strict-undefined semantics and general behavior for non-HTML/XML templates, while making HTML/XML rendering safe by default. All changes are local to `module_utils/jinja_strict.py`, in the `_jinja_env` function around line 60–63. No new external dependencies are required beyond Jinja2, which is already being imported.

Concretely:
- Update the `from jinja2 import ...` line to also import `select_autoescape`.
- Change the `return Environment(undefined=StrictUndefined)` line to `return Environment(undefined=StrictUndefined, autoescape=select_autoescape(["html", "xml"]))`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
