### PR TITLE
Potential fix for code scanning alert no. 168: Module is imported with 'import' and 'import from'

### DIFF
--- a/tests/unit/cli/deploy/dedicated/test_command_passthrough.py
+++ b/tests/unit/cli/deploy/dedicated/test_command_passthrough.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
 import unittest
-from unittest import mock
 
 from cli.deploy.dedicated import command as dedicated_command
 
 
 class TestDedicatedCommandPassthrough(unittest.TestCase):
-    @mock.patch("cli.deploy.dedicated.command.validate_application_ids")
-    @mock.patch("cli.deploy.dedicated.command.run_ansible_playbook")
-    @mock.patch("cli.deploy.dedicated.command.load_modes_from_yaml")
-    @mock.patch("cli.deploy.dedicated.command.add_dynamic_mode_args")
-    @mock.patch("cli.deploy.dedicated.command.build_modes_from_args")
+    @unittest.mock.patch("cli.deploy.dedicated.command.validate_application_ids")
+    @unittest.mock.patch("cli.deploy.dedicated.command.run_ansible_playbook")
+    @unittest.mock.patch("cli.deploy.dedicated.command.load_modes_from_yaml")
+    @unittest.mock.patch("cli.deploy.dedicated.command.add_dynamic_mode_args")
+    @unittest.mock.patch("cli.deploy.dedicated.command.build_modes_from_args")
     def test_main_passes_unknown_ansible_args_through(
         self,
         mock_build_modes_from_args,


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/168](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/168)

In general, to fix “module imported with both `import` and `from ... import ...`”, remove the `from ... import ...` line and, if necessary, access the imported names via the existing module namespace (e.g., `module.name`) or assign an alias.

Here, keep `import unittest` and remove `from unittest import mock`. Then update every usage of `mock` to use `unittest.mock` instead. Specifically in `tests/unit/cli/deploy/dedicated/test_command_passthrough.py`:

- Delete line 4: `from unittest import mock`.
- Replace each decorator `@mock.patch(...)` with `@unittest.mock.patch(...)`.

No new imports or helper methods are needed; `unittest.mock` is part of the standard library and already available through `import unittest`. Existing functionality remains unchanged because `unittest.mock.patch` is identical to `mock.patch` imported from `unittest`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
