### PR TITLE
Potential fix for code scanning alert no. 211: Implicit string concatenation in a list

### DIFF
--- a/tests/integration/test_compose_templates_require_image_for_build.py
+++ b/tests/integration/test_compose_templates_require_image_for_build.py
@@ -181,7 +181,7 @@ class TestComposeBuildRequiresImage(unittest.TestCase):
             # Pretty error output
             msg_lines = [
                 "Some sys-svc-compose templates/files contain a `build:` key but are missing an `image:` key "
-                "at the same indentation level (same YAML mapping level).",
+                + "at the same indentation level (same YAML mapping level).",
                 "",
                 "Offenders:",
             ]


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/211](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/211)

To fix this, we should remove the implicit string literal concatenation in the `msg_lines` list. The goal is to keep the runtime behavior the same (a single long first line in the error message), but make the concatenation explicit so it’s clear to both humans and tools.

The best minimal fix is to explicitly concatenate the two string literals with `+` within the same list element. That preserves a single-element message line while eliminating the implicit concatenation. Concretely, in `tests/integration/test_compose_templates_require_image_for_build.py`, in the `test_all_compose_templates_and_files_have_image_for_build` method, update the `msg_lines` initialization so that the two strings on lines 183 and 184 are combined with `+` into one expression. No new imports, methods, or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
