### PR TITLE
Potential fix for code scanning alert no. 225: Unused local variable

### DIFF
--- a/module_utils/templating.py
+++ b/module_utils/templating.py
@@ -296,7 +296,6 @@ def _templar_render_best_effort(templar: Any, s: str, variables: dict) -> str:
             except Exception:
                 # Best-effort cleanup: failure to restore disable_lookups is ignored,
                 # but we clear the flag to reflect that restoration did not succeed.
-                disable_changed_1 = False
 
     # Normalize to string (templar may return None)
     out_s = "" if rendered is None else str(rendered)


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/225](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/225)

In general, to fix an unused local variable, either remove the variable entirely or, if it is intentionally unused, rename it to follow an "unused" naming convention. Here, the problematic aspect is the assignment `disable_changed_1 = False` inside the `except Exception:` block at lines 295–299. That assignment does not influence any subsequent logic in the shown function, so it is safe to remove the write without changing existing functionality.

The best targeted fix is therefore to keep the `try`/`except` structure and its explanatory comment, but delete the line that assigns to `disable_changed_1`. This preserves the best-effort cleanup semantics and the comment, while avoiding an unused variable write. Concretely, in `module_utils/templating.py`, within the `finally` block where `_disable_lookups` and `disable_lookups` are restored, you will edit the `except Exception:` block following `setattr(templar, "disable_lookups", prev_disable_1)` to remove the `disable_changed_1 = False` line. No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
