### PR TITLE
Potential fix for code scanning alert no. 139: Module is imported with 'import' and 'import from'

### DIFF
--- a/tests/unit/module_utils/manager/test_inventory_manager.py
+++ b/tests/unit/module_utils/manager/test_inventory_manager.py
@@ -3,7 +3,6 @@
 import tempfile
 import unittest
 from pathlib import Path
-from unittest import mock
 
 from module_utils.manager.inventory import InventoryManager  # type: ignore
 from module_utils.handler.vault import VaultScalar  # type: ignore


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/139](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/139)

In general, to fix this issue you choose one import style per module: either `import unittest` and reference `unittest.mock`, or drop `import unittest` and do `from unittest import TestCase, main, mock` (or similar) and use those names directly. The recommendation given is to remove the `from xxx import yyy` form and, if necessary, use `xxx.yyy`.

For this file, the least intrusive change is to remove `from unittest import mock` and adjust references so that everything goes through the existing `unittest` import. The code already uses `unittest.TestCase` and `unittest.main`, and even uses `unittest.mock.patch` further down, so we only need to ensure that `mock` is consistently accessed via `unittest.mock`. Concretely:

- Delete line 6: `from unittest import mock`.
- If there are any direct uses of `mock` (e.g., `mock.patch(...)`) in the elided sections of the file, change them to `unittest.mock.patch(...)`. The shown snippet at lines 48–54 already uses `unittest.mock.patch`, so in the visible code no further edits are necessary.

All required names (`unittest`, `unittest.mock`) are from the standard library, so no additional imports or helper definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
