### PR TITLE
Potential fix for code scanning alert no. 212: Unused local variable

### DIFF
--- a/tests/unit/roles/sys-svc-compose-ca/files/test_compose_ca.py
+++ b/tests/unit/roles/sys-svc-compose-ca/files/test_compose_ca.py
@@ -478,7 +478,7 @@ class TestComposeCaInject(unittest.TestCase):
                 self.m, "docker_image_has_bin_sh", return_value=True
             ) as p_has_sh,
         ):
-            _doc = self.m.render_override(
+            self.m.render_override(
                 services,
                 service_to_cmd,
                 cwd=Path("/tmp"),


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/212](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/212)

To fix the problem, we should remove the unused local variable while preserving any side effects from the `render_override` call. That means replacing the assignment `_doc = self.m.render_override(...)` with a bare call `self.m.render_override(...)`. This keeps the test semantics identical: it still invokes `render_override` so that `docker_image_has_bin_sh` can be called and its `call_count` inspected afterwards, but it no longer introduces an unused local variable.

Concretely, in `tests/unit/roles/sys-svc-compose-ca/files/test_compose_ca.py`, in the body of `test_render_override_caches_bin_sh_probe_per_image`, replace the line starting with `_doc = self.m.render_override(` and its call continuation with a call that omits `_doc =`. No imports or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
