### PR TITLE
Potential fix for code scanning alert no. 218: Unused local variable

### DIFF
--- a/module_utils/templating.py
+++ b/module_utils/templating.py
@@ -246,7 +246,6 @@ def _templar_render_best_effort(templar: Any, s: str, variables: dict) -> str:
         return _fallback_render_embedded(s, variables)
 
     prev_avail: Optional[Any] = None
-    avail_changed = False
 
     # Temporarily force lookups ON (different Ansible versions use different flags)
     disable_changed_1, prev_disable_1 = _set_templar_var(
@@ -260,10 +259,8 @@ def _templar_render_best_effort(templar: Any, s: str, variables: dict) -> str:
         try:
             prev_avail = templar.available_variables
             templar.available_variables = variables
-            avail_changed = True
         except Exception:
             prev_avail = None
-            avail_changed = False
 
     try:
         try:
@@ -271,17 +268,12 @@ def _templar_render_best_effort(templar: Any, s: str, variables: dict) -> str:
         except TypeError:
             rendered = templar.template(s)
     finally:
-        if (
-            avail_changed
-            and prev_avail is not None
-            and hasattr(templar, "available_variables")
-        ):
+        if prev_avail is not None and hasattr(templar, "available_variables"):
             try:
                 templar.available_variables = prev_avail
             except Exception:
-                # Best-effort cleanup: failure to restore available_variables is ignored,
-                # but we clear the flag to reflect that restoration did not succeed.
-                avail_changed = False
+                # Best-effort cleanup: failure to restore available_variables is ignored.
+                pass
 
         if disable_changed_2:
             try:


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/218](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/218)

In general, to fix an “unused local variable” warning, either remove the variable (and any dead writes to it) if it truly has no effect, or, if it is intentionally unused, rename it to something like `_unused_var` to signal intent. Here, `avail_changed` is only used to gate restoration of `templar.available_variables` in the `finally` block; we can inline that condition directly as “only restore if we successfully assigned earlier” without needing a separate flag.

The safest fix that doesn’t change behavior is:

- Remove the `avail_changed` variable declaration at line 249.
- In the `try` block where `templar.available_variables` is assigned (lines 259–266), stop toggling `avail_changed`; simply record `prev_avail` on success and set it back to `None` on failure.
- In the `finally` block, change the condition `if (avail_changed and prev_avail is not None and hasattr(...)):` to a condition based solely on `prev_avail` and `hasattr(templar, "available_variables")`. This preserves the original behavior: restoration is attempted only if `prev_avail` was set to a non-`None` value (i.e., the earlier assignment succeeded).
- Remove the line that sets `avail_changed = False` in the `except` block at lines 282–284, since the flag will no longer exist.

All required changes are within `module_utils/templating.py` in the `_templar_render_best_effort` function; no new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
