### PR TITLE
Potential fix for code scanning alert no. 219: Unused local variable

### DIFF
--- a/module_utils/templating.py
+++ b/module_utils/templating.py
@@ -289,7 +289,7 @@ def _templar_render_best_effort(templar: Any, s: str, variables: dict) -> str:
             except Exception:
                 # Best-effort cleanup: failure to restore _disable_lookups is ignored,
                 # but we clear the flag to reflect that restoration did not succeed.
-                disable_changed_2 = False
+                pass
         if disable_changed_1:
             try:
                 setattr(templar, "disable_lookups", prev_disable_1)


### PR DESCRIPTION
Potential fix for [https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/219](https://github.com/kevinveenbirkenbach/infinito-nexus/security/code-scanning/219)

In general, to fix an unused local variable, either (1) remove assignments that serve no purpose, preserving any right-hand-side expressions that may have side effects, or (2) if the variable is intentionally unused, rename it to a conventional unused name (e.g., `_` or `unused_*`). Here, the right-hand side of the assignment is just the literal `False` with no side effects, and `disable_changed_2` is not read later, so the assignment is superfluous.

The best fix with no functional change is to delete the line `disable_changed_2 = False` at line 292 and keep the rest of the error-handling logic as is. The try/except still documents that restoration failures are intentionally ignored. No additional imports or definitions are required. The change is confined to `module_utils/templating.py`, in the shown `finally` cleanup section of whatever function this is part of.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
