### PR TITLE
Fix test-dns CI image selection

### DIFF
--- a/.github/workflows/test-dns.yml
+++ b/.github/workflows/test-dns.yml
@@ -50,6 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: prepare
+    env:
+      NIX_CONFIG: |
+        access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      INFINITO_IMAGE_TAG: ci-${{ github.sha }}
+      # Use the prebuilt CI image directly instead of the :latest fallback from env.sh.
+      INFINITO_IMAGE: ghcr.io/${{ github.repository_owner }}/infinito-${{ matrix.distro }}:ci-${{ github.sha }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

* Fix `test-dns` so it uses the prebuilt CI image instead of falling back to the default `:latest` image
* Align DNS test workflow image selection with the existing `build-ci-images` flow
* Improve CI reliability for normal runs and fork PR runs

---

## Change Type

* [ ] **Major** – Breaking change (incompatible configuration or behaviour)
* [ ] **Minor** – New feature or new role (backwards compatible)
* [x] **Patch** – Bugfix or internal improvement

---

## Impacted Areas

* [ ] Role implementation
* [ ] Configuration variables
* [ ] Documentation
* [x] CI/CD
* [ ] Security

---

## Description of Changes

The `test-dns` workflow did not explicitly set the CI image name or tag before running `make up`. Because of that, the workflow fell back to the default image resolution from `scripts/meta/env.sh`, which produced `ghcr.io/<owner>/infinito-<distro>:latest`.

This was incorrect because the CI pipeline already builds and expects images tagged as `ci-${github.sha}`. As a result, `test-dns` tried to start a container from an image that did not exist, causing the job to fail before the DNS test suite could run.

The implementation adds explicit job-level environment variables in `.github/workflows/test-dns.yml`:

* `INFINITO_IMAGE_TAG=ci-${{ github.sha }}`
* `INFINITO_IMAGE=ghcr.io/${{ github.repository_owner }}/infinito-${{ matrix.distro }}:ci-${{ github.sha }}`

This approach was chosen because it is minimal, targeted, and consistent with the rest of the CI setup. It avoids relying on implicit fallback behavior and makes the workflow contract explicit.

Alternative approaches would have been:

* deriving the image only through shared defaults in `env.sh`
* introducing a reusable workflow input for the resolved image tag

Those options are possible, but this change keeps the fix small and directly addresses the failing workflow.

---

## Definition of Done (DoD)

### Workflow

* [x] Contributions follow the [collaboration workflow](https://hub.infinito.nexus/t/working-with-folks-in-infinito-nexus/436).

### Code Quality

* [x] Code follows repository conventions
* [x] Code and comments are written in English

### Functionality

* [x] Feature works as expected

---

## Checklist for Reviewer

* [x] Code is understandable
* [x] Changes follow project guidelines
* [x] No obvious security issues

---

## Additional Notes

This change is intentionally limited to the workflow layer and does not modify application or role logic.

The main goal is to ensure that `test-dns` consumes the same image naming contract as the rest of the CI pipeline, including fork PR scenarios that rely on prebuilt images for the PR merge SHA.