### PR TITLE
feat(web-app-mattermost): add Playwright E2E test coverage

### DIFF
--- a/roles/web-app-mattermost/README.md
+++ b/roles/web-app-mattermost/README.md
@@ -1,4 +1,4 @@
-# web-app-mattermost
+# Mattermost
 
 Deploys [Mattermost Team Edition](https://mattermost.com/) — an open-source, self-hosted team messaging platform — as part of the Infinito.Nexus stack.
 

--- a/roles/web-app-mattermost/files/playwright.spec.js
+++ b/roles/web-app-mattermost/files/playwright.spec.js
@@ -112,15 +112,13 @@ async function waitForMattermostChannelView(frame, timeout = 60_000) {
   return waitForFirstVisible([channelSidebar, townSquare], timeout);
 }
 
-// Log out of Mattermost via the REST API rather than navigating to /logout.
-// The nginx vhost for every app intercepts `location = /logout` and proxies it to the
-// universal-logout service (web-svc-logout), which triggers a multi-domain OIDC logout
-// redirect chain that causes net::ERR_ABORTED in Playwright. Calling the Mattermost
-// API endpoint directly invalidates the session without going through nginx /logout.
+// Log out via the universal logout endpoint.
+// Every app's nginx vhost intercepts `location = /logout` and proxies it to
+// web-svc-logout, which terminates all active sessions across all apps.
+// Using `waitUntil: 'commit'` avoids net::ERR_ABORTED from the multi-domain
+// redirect chain the service triggers after invalidating the session.
 async function mattermostLogout(page, baseUrl) {
-  await page.evaluate(async (apiUrl) => {
-    await fetch(apiUrl, { method: "POST", credentials: "include" }).catch(() => {});
-  }, `${baseUrl.replace(/\/$/, "")}/api/v4/users/logout`);
+  await page.goto(`${baseUrl.replace(/\/$/, "")}/logout`, { waitUntil: "commit" }).catch(() => {});
 }
 
 test.beforeEach(() => {
@@ -182,14 +180,16 @@ test("dashboard to mattermost: sso login, verify channel view, logout", async ({
   // intercept that routes to the universal-logout service.
   await mattermostLogout(page, expectedMattermostBaseUrl);
 
-  // 10. Verify the session is gone — Mattermost should redirect to login for unauthenticated requests.
+  // 10. Verify the session is gone — Mattermost should redirect to login or landing
+  // for unauthenticated requests. In Mattermost v11+ the default unauthenticated
+  // redirect is /landing#/ rather than /login.
   await page.goto(`${expectedMattermostBaseUrl}/`, { waitUntil: "domcontentloaded" });
   await expect
     .poll(() => page.url(), {
       timeout: 15_000,
-      message: "Expected Mattermost to redirect to login after logout"
+      message: "Expected Mattermost to redirect to /login or /landing after logout"
     })
-    .toContain("/login");
+    .toMatch(/\/(login|landing)/);
 
   await page.goto("/");
 });
@@ -237,10 +237,10 @@ test("mattermost: biber sends direct message to administrator, administrator rec
     // Dismiss onboarding popups that appear for new SSO users
     await dismissMattermostPopups(biberPage);
 
-    // Wait for the channel view to load
-    await waitForMattermostChannelView(biberPage, 30_000);
-
     // Open DM with administrator by navigating directly to the DM URL.
+    // On first login biber has no team membership and lands on /select_team —
+    // navigating to /{team}/messages/@{username} auto-joins the open team and
+    // opens the DM in one step, so waitForMattermostChannelView is not needed here.
     // Mattermost v11 supports /{team}/messages/@{username} — more reliable than
     // clicking the sidebar "New DM" button whose aria-label changed across versions.
     await biberPage.goto(`${expectedMattermostBaseUrl}/main/messages/@${adminUsername}`);

--- a/roles/web-app-mattermost/files/playwright.spec.js
+++ b/roles/web-app-mattermost/files/playwright.spec.js
@@ -1,0 +1,310 @@
+const { test, expect } = require("@playwright/test");
+
+test.use({
+  ignoreHTTPSErrors: true
+});
+
+function decodeDotenvQuotedValue(value) {
+  if (typeof value !== "string" || value.length < 2) {
+    return value;
+  }
+
+  if (!(value.startsWith('"') && value.endsWith('"'))) {
+    return value;
+  }
+
+  const encoded = value.slice(1, -1);
+
+  try {
+    return JSON.parse(`"${encoded}"`).replace(/\$\$/g, "$");
+  } catch {
+    return encoded.replace(/\$\$/g, "$");
+  }
+}
+
+// `docker --env-file` preserves the quotes emitted by `dotenv_quote`,
+// so normalize these values before building URLs or typing credentials.
+const oidcIssuerUrl      = decodeDotenvQuotedValue(process.env.OIDC_ISSUER_URL);
+const mattermostBaseUrl  = decodeDotenvQuotedValue(process.env.MATTERMOST_BASE_URL);
+const adminUsername      = decodeDotenvQuotedValue(process.env.ADMIN_USERNAME);
+const adminPassword      = decodeDotenvQuotedValue(process.env.ADMIN_PASSWORD);
+const biberUsername      = decodeDotenvQuotedValue(process.env.BIBER_USERNAME);
+const biberPassword      = decodeDotenvQuotedValue(process.env.BIBER_PASSWORD);
+
+async function waitForFirstVisible(locators, timeout = 60_000) {
+  const deadline = Date.now() + timeout;
+
+  while (Date.now() < deadline) {
+    for (const locator of locators) {
+      if (await locator.first().isVisible().catch(() => false)) {
+        return locator.first();
+      }
+    }
+
+    await new Promise(r => setTimeout(r, 500));
+  }
+
+  throw new Error("Timed out waiting for one of the expected selectors to become visible");
+}
+
+// Perform SSO login via Keycloak inside a frame context (or page context for direct navigation).
+async function performOidcLogin(frame, username, password) {
+  const usernameField = frame.getByRole("textbox", { name: /username|email/i });
+  const passwordField = frame.getByRole("textbox", { name: "Password" });
+  const signInButton  = frame.getByRole("button", { name: /sign in/i });
+
+  await usernameField.waitFor({ state: "visible", timeout: 60_000 });
+  await usernameField.fill(username);
+  await usernameField.press("Tab");
+  await passwordField.fill(password);
+  await signInButton.click();
+}
+
+// Navigate directly to the Mattermost GitLab OAuth2 login endpoint.
+// This bypasses the login page button rendering (which requires EnableSignInWithGitLab
+// in the client config) and also bypasses the /landing app-selection dialog that
+// Mattermost shows for fresh browser contexts in v11+.
+async function startMattermostSsoFlow(page, baseUrl) {
+  await page.goto(`${baseUrl.replace(/\/$/, "")}/oauth/gitlab/login`);
+}
+
+// Dismiss Mattermost onboarding modals/tips that may appear after first SSO login.
+async function dismissMattermostPopups(frame) {
+  const dismissSelectors = [
+    // Existing selectors
+    frame.getByRole("button", { name: /next|done|skip|got it|close|ok/i }),
+    frame.locator("[aria-label='Close'], .modal-header .close, button.close"),
+    // NEW: Target the specific onboarding overlay causing the intercept error
+    frame.locator("[data-cy='onboarding-task-list-overlay']"),
+    frame.locator(".onboarding-tour-tip__close"),
+  ];
+
+  for (let round = 0; round < 3; round++) {
+    for (const sel of dismissSelectors) {
+      if (await sel.first().isVisible({ timeout: 2000 }).catch(() => false)) {
+        // If it's the overlay itself, we might need to click a specific 'X' or 'Skip' inside it
+        // but often clicking the element or pressing Escape works.
+        await sel.first().click({ force: true }).catch(() => {});
+        await new Promise(r => setTimeout(r, 500));
+      }
+    }
+
+    // Forcefully hide the onboarding root if it persists via CSS 
+    // (This is a 'hammer' approach if the click fails)
+    await frame.evaluate(() => {
+      document.querySelectorAll("[data-cy='onboarding-task-list-overlay']").forEach(el => el.remove());
+      document.querySelectorAll("#root-portal").forEach(el => el.style.display = 'none');
+    }).catch(() => {});
+
+    await frame.locator("body").press("Escape").catch(() => {});
+    await new Promise(r => setTimeout(r, 500));
+  }
+}
+
+// Wait for Mattermost's main channel view to finish loading.
+// Returns the first visible indicator (channel sidebar or Town Square link).
+async function waitForMattermostChannelView(frame, timeout = 60_000) {
+  const channelSidebar = frame.locator(
+    ".SidebarChannel, [data-testid='channel_sidebar'], #sidebar-left, .SidebarNavContainer"
+  );
+  const townSquare = frame.getByText("Town Square");
+
+  return waitForFirstVisible([channelSidebar, townSquare], timeout);
+}
+
+// Log out of Mattermost via the REST API rather than navigating to /logout.
+// The nginx vhost for every app intercepts `location = /logout` and proxies it to the
+// universal-logout service (web-svc-logout), which triggers a multi-domain OIDC logout
+// redirect chain that causes net::ERR_ABORTED in Playwright. Calling the Mattermost
+// API endpoint directly invalidates the session without going through nginx /logout.
+async function mattermostLogout(page, baseUrl) {
+  await page.evaluate(async (apiUrl) => {
+    await fetch(apiUrl, { method: "POST", credentials: "include" }).catch(() => {});
+  }, `${baseUrl.replace(/\/$/, "")}/api/v4/users/logout`);
+}
+
+test.beforeEach(() => {
+  expect(oidcIssuerUrl,     "OIDC_ISSUER_URL must be set in the Playwright env file").toBeTruthy();
+  expect(mattermostBaseUrl, "MATTERMOST_BASE_URL must be set in the Playwright env file").toBeTruthy();
+  expect(adminUsername,     "ADMIN_USERNAME must be set in the Playwright env file").toBeTruthy();
+  expect(adminPassword,     "ADMIN_PASSWORD must be set in the Playwright env file").toBeTruthy();
+  expect(biberUsername,     "BIBER_USERNAME must be set in the Playwright env file").toBeTruthy();
+  expect(biberPassword,     "BIBER_PASSWORD must be set in the Playwright env file").toBeTruthy();
+});
+
+// Scenario I: dashboard → click Mattermost → verify iframe → SSO login → verify channel view → logout
+//
+// The SSO flow is triggered by navigating directly to /oauth/gitlab/login rather than
+// clicking the login-page button. In Mattermost v11 Team Edition, the EnableSignInWithGitLab
+// key may be absent from the client config API even when GitLabSettings.Enable=true, which
+// causes the React frontend to not render the button. Direct navigation is functionally
+// equivalent and avoids the button-rendering dependency.
+test("dashboard to mattermost: sso login, verify channel view, logout", async ({ page }) => {
+  const expectedOidcAuthUrl       = `${oidcIssuerUrl.replace(/\/$/, "")}/protocol/openid-connect/auth`;
+  const expectedMattermostBaseUrl = mattermostBaseUrl.replace(/\/$/, "");
+
+  // 1. Navigate to dashboard and click Mattermost app link
+  await page.goto("/");
+  await page.getByRole("link", { name: "Explore Mattermost" }).click();
+
+  // 2. Verify the Mattermost iframe is present on the dashboard (confirms dashboard integration)
+  await expect(page.locator("#main iframe")).toBeVisible();
+
+  // 3. Trigger SSO by navigating directly to the GitLab OAuth2 endpoint
+  await startMattermostSsoFlow(page, expectedMattermostBaseUrl);
+
+  // 4. Wait for redirect to Keycloak OIDC auth
+  await expect
+    .poll(() => page.url(), {
+      timeout: 60_000,
+      message: `Expected redirect to Keycloak OIDC: ${expectedOidcAuthUrl}`
+    })
+    .toContain(expectedOidcAuthUrl);
+
+  // 5. Fill credentials and sign in via Keycloak
+  await performOidcLogin(page, adminUsername, adminPassword);
+
+  // 6. Wait for redirect back to Mattermost after successful auth
+  await expect
+    .poll(() => page.url(), {
+      timeout: 60_000,
+      message: `Expected redirect back to Mattermost: ${expectedMattermostBaseUrl}`
+    })
+    .toContain(expectedMattermostBaseUrl);
+
+  // 7. Dismiss any onboarding popups that appear after first SSO login
+  await dismissMattermostPopups(page);
+
+  // 8. Verify logged in — channel sidebar or Town Square must be visible
+  await waitForMattermostChannelView(page, 30_000);
+
+  // 9. Logout via API — session is invalidated without going through the nginx /logout
+  // intercept that routes to the universal-logout service.
+  await mattermostLogout(page, expectedMattermostBaseUrl);
+
+  // 10. Verify the session is gone — Mattermost should redirect to login for unauthenticated requests.
+  await page.goto(`${expectedMattermostBaseUrl}/`, { waitUntil: "domcontentloaded" });
+  await expect
+    .poll(() => page.url(), {
+      timeout: 15_000,
+      message: "Expected Mattermost to redirect to login after logout"
+    })
+    .toContain("/login");
+
+  await page.goto("/");
+});
+
+// Scenario II: biber logs in → sends direct message to administrator → administrator logs in
+//              (separate browser) → verifies message → both log out
+//
+// Using isolated browser contexts models two separate users on separate machines:
+// no shared cookies, no shared Keycloak SSO session.
+test("mattermost: biber sends direct message to administrator, administrator receives it", async ({ browser }) => {
+  const expectedOidcAuthUrl       = `${oidcIssuerUrl.replace(/\/$/, "")}/protocol/openid-connect/auth`;
+  const expectedMattermostBaseUrl = mattermostBaseUrl.replace(/\/$/, "");
+  const testMessage               = `Playwright test ${Date.now()}`;
+
+  // Separate contexts = separate browser profiles (no shared cookies or SSO session)
+  const biberContext = await browser.newContext({ ignoreHTTPSErrors: true });
+  const adminContext = await browser.newContext({ ignoreHTTPSErrors: true });
+
+  try {
+    // --- Part 1: biber logs in and sends a direct message to administrator ---
+
+    const biberPage = await biberContext.newPage();
+
+    // Trigger SSO directly — bypasses /landing app-selection dialog for fresh contexts
+    await startMattermostSsoFlow(biberPage, expectedMattermostBaseUrl);
+
+    // Wait for redirect to Keycloak OIDC auth page
+    await expect
+      .poll(() => biberPage.url(), {
+        timeout: 30_000,
+        message: `Expected redirect to Keycloak OIDC: ${expectedOidcAuthUrl}`
+      })
+      .toContain(expectedOidcAuthUrl);
+
+    await performOidcLogin(biberPage, biberUsername, biberPassword);
+
+    // Wait for redirect back to Mattermost (any path under the base URL)
+    await expect
+      .poll(() => biberPage.url(), {
+        timeout: 60_000,
+        message: "Expected redirect back to Mattermost after biber login"
+      })
+      .toContain(expectedMattermostBaseUrl);
+
+    // Dismiss onboarding popups that appear for new SSO users
+    await dismissMattermostPopups(biberPage);
+
+    // Wait for the channel view to load
+    await waitForMattermostChannelView(biberPage, 30_000);
+
+    // Open DM with administrator by navigating directly to the DM URL.
+    // Mattermost v11 supports /{team}/messages/@{username} — more reliable than
+    // clicking the sidebar "New DM" button whose aria-label changed across versions.
+    await biberPage.goto(`${expectedMattermostBaseUrl}/main/messages/@${adminUsername}`);
+
+    // Wait for the DM channel to open — message input must be visible
+    const messageInput = biberPage
+      .locator("#post_textbox, [data-testid='post_textbox'], div[contenteditable='true'].post-create__input")
+      .first();
+
+    await messageInput.waitFor({ state: "visible", timeout: 30_000 });
+    await messageInput.click({ force: true });
+    // Use keyboard.type() rather than fill() — Mattermost's rich-text editor is a
+    // contenteditable div and fill() bypasses React's onChange handlers, leaving the
+    // component state empty even though the text is visible in the DOM.
+    await biberPage.keyboard.type(testMessage);
+
+    // Send the message (Enter key submits; Shift+Enter inserts a newline)
+    await biberPage.keyboard.press("Enter");
+
+    // Confirm the message appears in the channel.
+    // getByTestId('postContent') scopes to the post body, avoiding strict-mode
+    // violations from Mattermost's screen-reader <span> that duplicates the text.
+    await expect(biberPage.getByTestId("postContent").getByText(testMessage)).toBeVisible({ timeout: 15_000 });
+
+    // Logout as biber
+    await mattermostLogout(biberPage, expectedMattermostBaseUrl);
+
+    // --- Part 2: administrator logs in and verifies the direct message (fresh browser context) ---
+
+    const adminPage = await adminContext.newPage();
+
+    // Trigger SSO directly — bypasses /landing app-selection dialog for fresh contexts
+    await startMattermostSsoFlow(adminPage, expectedMattermostBaseUrl);
+
+    await expect
+      .poll(() => adminPage.url(), {
+        timeout: 30_000,
+        message: `Expected redirect to Keycloak OIDC: ${expectedOidcAuthUrl}`
+      })
+      .toContain(expectedOidcAuthUrl);
+
+    await performOidcLogin(adminPage, adminUsername, adminPassword);
+
+    await expect
+      .poll(() => adminPage.url(), {
+        timeout: 60_000,
+        message: "Expected redirect back to Mattermost after admin login"
+      })
+      .toContain(expectedMattermostBaseUrl);
+
+    await dismissMattermostPopups(adminPage);
+    await waitForMattermostChannelView(adminPage, 30_000);
+
+    // Open DM with biber by navigating directly to the DM URL.
+    await adminPage.goto(`${expectedMattermostBaseUrl}/main/messages/@${biberUsername}`);
+
+    // Verify biber's message is visible in the DM channel
+    await expect(adminPage.getByTestId("postContent").getByText(testMessage)).toBeVisible({ timeout: 30_000 });
+
+    // Logout as administrator
+    await mattermostLogout(adminPage, expectedMattermostBaseUrl);
+
+  } finally {
+    await biberContext.close().catch(() => {});
+    await adminContext.close().catch(() => {});
+  }
+});

--- a/roles/web-app-mattermost/tasks/01_setup.yml
+++ b/roles/web-app-mattermost/tasks/01_setup.yml
@@ -26,19 +26,6 @@
   changed_when: mm_create_admin.rc == 0
   failed_when: mm_create_admin.rc != 0 and 'already exists' not in (mm_create_admin.stdout + mm_create_admin.stderr)
 
-- name: "Mattermost | Create biber user"
-  shell: |
-    container exec -i {{ MATTERMOST_CONTAINER }} \
-      /mattermost/bin/mmctl --local user create \
-        --email    "{{ users.biber.email }}" \
-        --username "{{ users.biber.username }}" \
-        --password {{ users.biber.password | quote }}
-  args:
-    chdir: "{{ lookup('container', application_id, 'directories.instance') }}"
-  register: mm_create_biber
-  changed_when: mm_create_biber.rc == 0
-  failed_when: mm_create_biber.rc != 0 and 'already exists' not in (mm_create_biber.stdout + mm_create_biber.stderr)
-
 - name: "Mattermost | Create default team"
   shell: |
     container exec -i {{ MATTERMOST_CONTAINER }} \
@@ -50,6 +37,16 @@
   register: mm_create_team
   changed_when: mm_create_team.rc == 0
   failed_when: mm_create_team.rc != 0 and 'already exists' not in (mm_create_team.stdout + mm_create_team.stderr) and 'existing team' not in (mm_create_team.stdout + mm_create_team.stderr)
+
+- name: "Mattermost | Enable open invite on default team"
+  shell: |
+    container exec -i {{ lookup('database', application_id, 'container') }} \
+      psql -U {{ lookup('database', application_id, 'username') }} \
+           -d {{ lookup('database', application_id, 'name') }} \
+           -c "UPDATE teams SET allowopeninvite = true WHERE name = 'main';"
+  args:
+    chdir: "{{ lookup('container', application_id, 'directories.instance') }}"
+  changed_when: false
 
 - name: "Mattermost | Check which users are already in default team"
   shell: |
@@ -69,16 +66,6 @@
   args:
     chdir: "{{ lookup('container', application_id, 'directories.instance') }}"
   when: users.administrator.email not in mm_team_members.stdout
-
-- name: "Mattermost | Add biber to default team"
-  shell: |
-    container exec -i {{ MATTERMOST_CONTAINER }} \
-      /mattermost/bin/mmctl --local team users add \
-        main \
-        "{{ users.biber.email }}"
-  args:
-    chdir: "{{ lookup('container', application_id, 'directories.instance') }}"
-  when: users.biber.email not in mm_team_members.stdout
 
 - name: "Mattermost | Check administrator auth service"
   shell: |
@@ -122,44 +109,3 @@
     - MATTERMOST_OIDC_ENABLED | bool
     - mm_admin_authservice.stdout | trim != 'gitlab'
 
-- name: "Mattermost | Check biber auth service"
-  shell: |
-    container exec -i {{ lookup('database', application_id, 'container') }} \
-      psql -U {{ lookup('database', application_id, 'username') }} \
-           -d {{ lookup('database', application_id, 'name') }} \
-           -t -c "SELECT authservice FROM users WHERE email='{{ users.biber.email }}';"
-  args:
-    chdir: "{{ lookup('container', application_id, 'directories.instance') }}"
-  register: mm_biber_authservice
-  changed_when: false
-  when: MATTERMOST_OIDC_ENABLED | bool
-
-- name: "Mattermost | Get biber uidNumber from LDAP"
-  shell: |
-    container exec -i {{ MATTERMOST_LDAP_CONTAINER }} \
-      ldapsearch -x -H ldap://localhost:389 \
-        -D {{ LDAP.DN.ADMINISTRATOR.DATA | quote }} \
-        -w {{ LDAP.BIND_CREDENTIAL | quote }} \
-        -b {{ LDAP.DN.OU.USERS | quote }} \
-        "(uid={{ users.biber.username }})" uidNumber \
-    | grep '^uidNumber:' | awk '{print $2}'
-  args:
-    chdir: "{{ lookup('container', application_id, 'directories.instance') }}"
-  register: mm_biber_uidnumber
-  changed_when: false
-  failed_when: mm_biber_uidnumber.rc != 0 or mm_biber_uidnumber.stdout | trim == ''
-  when:
-    - MATTERMOST_OIDC_ENABLED | bool
-    - mm_biber_authservice.stdout | trim != 'gitlab'
-
-- name: "Mattermost | Convert biber to gitlab SSO auth"
-  shell: |
-    container exec -i {{ lookup('database', application_id, 'container') }} \
-      psql -U {{ lookup('database', application_id, 'username') }} \
-           -d {{ lookup('database', application_id, 'name') }} \
-           -c "UPDATE users SET authservice='gitlab', authdata='{{ mm_biber_uidnumber.stdout | trim }}', password='' WHERE email='{{ users.biber.email }}';"
-  args:
-    chdir: "{{ lookup('container', application_id, 'directories.instance') }}"
-  when:
-    - MATTERMOST_OIDC_ENABLED | bool
-    - mm_biber_authservice.stdout | trim != 'gitlab'

--- a/roles/web-app-mattermost/tasks/01_setup.yml
+++ b/roles/web-app-mattermost/tasks/01_setup.yml
@@ -1,4 +1,17 @@
 ---
+- name: "Mattermost | Wait until mmctl local mode is ready"
+  shell: |
+    container exec -i {{ MATTERMOST_CONTAINER }} \
+      /mattermost/bin/mmctl --local system status
+  args:
+    chdir: "{{ lookup('container', application_id, 'directories.instance') }}"
+  register: mm_ready_wait
+  retries: 60
+  delay: 5
+  until: mm_ready_wait.rc == 0
+  changed_when: false
+  failed_when: mm_ready_wait.rc != 0 and mm_ready_wait.attempts == 61
+
 - name: "Mattermost | Create system administrator user"
   shell: |
     container exec -i {{ MATTERMOST_CONTAINER }} \
@@ -13,6 +26,19 @@
   changed_when: mm_create_admin.rc == 0
   failed_when: mm_create_admin.rc != 0 and 'already exists' not in (mm_create_admin.stdout + mm_create_admin.stderr)
 
+- name: "Mattermost | Create biber user"
+  shell: |
+    container exec -i {{ MATTERMOST_CONTAINER }} \
+      /mattermost/bin/mmctl --local user create \
+        --email    "{{ users.biber.email }}" \
+        --username "{{ users.biber.username }}" \
+        --password {{ users.biber.password | quote }}
+  args:
+    chdir: "{{ lookup('container', application_id, 'directories.instance') }}"
+  register: mm_create_biber
+  changed_when: mm_create_biber.rc == 0
+  failed_when: mm_create_biber.rc != 0 and 'already exists' not in (mm_create_biber.stdout + mm_create_biber.stderr)
+
 - name: "Mattermost | Create default team"
   shell: |
     container exec -i {{ MATTERMOST_CONTAINER }} \
@@ -25,7 +51,7 @@
   changed_when: mm_create_team.rc == 0
   failed_when: mm_create_team.rc != 0 and 'already exists' not in (mm_create_team.stdout + mm_create_team.stderr) and 'existing team' not in (mm_create_team.stdout + mm_create_team.stderr)
 
-- name: "Mattermost | Check if administrator is already in default team"
+- name: "Mattermost | Check which users are already in default team"
   shell: |
     container exec -i {{ MATTERMOST_CONTAINER }} \
       /mattermost/bin/mmctl --local user list --team main
@@ -43,6 +69,16 @@
   args:
     chdir: "{{ lookup('container', application_id, 'directories.instance') }}"
   when: users.administrator.email not in mm_team_members.stdout
+
+- name: "Mattermost | Add biber to default team"
+  shell: |
+    container exec -i {{ MATTERMOST_CONTAINER }} \
+      /mattermost/bin/mmctl --local team users add \
+        main \
+        "{{ users.biber.email }}"
+  args:
+    chdir: "{{ lookup('container', application_id, 'directories.instance') }}"
+  when: users.biber.email not in mm_team_members.stdout
 
 - name: "Mattermost | Check administrator auth service"
   shell: |
@@ -86,3 +122,44 @@
     - MATTERMOST_OIDC_ENABLED | bool
     - mm_admin_authservice.stdout | trim != 'gitlab'
 
+- name: "Mattermost | Check biber auth service"
+  shell: |
+    container exec -i {{ lookup('database', application_id, 'container') }} \
+      psql -U {{ lookup('database', application_id, 'username') }} \
+           -d {{ lookup('database', application_id, 'name') }} \
+           -t -c "SELECT authservice FROM users WHERE email='{{ users.biber.email }}';"
+  args:
+    chdir: "{{ lookup('container', application_id, 'directories.instance') }}"
+  register: mm_biber_authservice
+  changed_when: false
+  when: MATTERMOST_OIDC_ENABLED | bool
+
+- name: "Mattermost | Get biber uidNumber from LDAP"
+  shell: |
+    container exec -i {{ MATTERMOST_LDAP_CONTAINER }} \
+      ldapsearch -x -H ldap://localhost:389 \
+        -D {{ LDAP.DN.ADMINISTRATOR.DATA | quote }} \
+        -w {{ LDAP.BIND_CREDENTIAL | quote }} \
+        -b {{ LDAP.DN.OU.USERS | quote }} \
+        "(uid={{ users.biber.username }})" uidNumber \
+    | grep '^uidNumber:' | awk '{print $2}'
+  args:
+    chdir: "{{ lookup('container', application_id, 'directories.instance') }}"
+  register: mm_biber_uidnumber
+  changed_when: false
+  failed_when: mm_biber_uidnumber.rc != 0 or mm_biber_uidnumber.stdout | trim == ''
+  when:
+    - MATTERMOST_OIDC_ENABLED | bool
+    - mm_biber_authservice.stdout | trim != 'gitlab'
+
+- name: "Mattermost | Convert biber to gitlab SSO auth"
+  shell: |
+    container exec -i {{ lookup('database', application_id, 'container') }} \
+      psql -U {{ lookup('database', application_id, 'username') }} \
+           -d {{ lookup('database', application_id, 'name') }} \
+           -c "UPDATE users SET authservice='gitlab', authdata='{{ mm_biber_uidnumber.stdout | trim }}', password='' WHERE email='{{ users.biber.email }}';"
+  args:
+    chdir: "{{ lookup('container', application_id, 'directories.instance') }}"
+  when:
+    - MATTERMOST_OIDC_ENABLED | bool
+    - mm_biber_authservice.stdout | trim != 'gitlab'

--- a/roles/web-app-mattermost/templates/env.j2
+++ b/roles/web-app-mattermost/templates/env.j2
@@ -6,6 +6,7 @@ MM_SERVICESETTINGS_SITEURL={{ lookup('tls', application_id, 'url.base') }}
 MM_SERVICESETTINGS_LISTENADDRESS=:{{ container_port }}
 MM_SERVICESETTINGS_ALLOWCORSFROM={{ lookup('tls', application_id, 'url.base') }}
 MM_SERVICESETTINGS_ENABLELOCALMODE=true
+MM_EXPERIMENTALSETTINGS_DISABLELANDINGPAGE=true
 
 # Logging
 MM_LOGSETTINGS_CONSOLELEVEL={% if MODE_DEBUG | bool %}DEBUG{% else %}INFO{% endif %}

--- a/roles/web-app-mattermost/templates/playwright.env.j2
+++ b/roles/web-app-mattermost/templates/playwright.env.j2
@@ -1,0 +1,7 @@
+APP_BASE_URL={{ lookup('tls', 'web-app-dashboard', 'url.base') }}
+OIDC_ISSUER_URL={{ OIDC.CLIENT.ISSUER_URL | dotenv_quote }}
+MATTERMOST_BASE_URL={{ lookup('tls', 'web-app-mattermost', 'url.base') | dotenv_quote }}
+ADMIN_USERNAME={{ users.administrator.username | dotenv_quote }}
+ADMIN_PASSWORD={{ users.administrator.password | dotenv_quote }}
+BIBER_USERNAME={{ users.biber.username | dotenv_quote }}
+BIBER_PASSWORD={{ users.biber.password | dotenv_quote }}


### PR DESCRIPTION
## Summary

Add Playwright E2E test coverage for `web-app-mattermost`. Two scenarios are covered: SSO login via GitLab OAuth2 with channel view verification and API logout; and a biber → administrator direct message flow using isolated browser contexts.

---

## Template Type

* [x] **Feature** - Adds or extends server functionality

---

## Affected Roles and Services

* Primary `web-*` role(s): `web-app-mattermost`
* Related roles: `web-svc-gitlab` (OIDC/SSO), LDAP

## Preferred Integrations

* [ ] Dashboard
* [ ] Matomo
* [x] OIDC
* [x] LDAP
* [x] Logout

---

## Change Type

* [ ] **Major** - Breaking change
* [x] **Minor** - New backwards-compatible feature
* [ ] **Patch** - Small improvement or compatible adjustment

---

## Change Details

**Problem:** `web-app-mattermost` had no automated E2E test coverage.

**Solution:**

- `playwright.spec.js`: two test scenarios
  - SSO login via GitLab OAuth2 endpoint (works around missing `EnableSignInWithGitLab` client config key in Mattermost v11.5.1), channel view verification, and API-based logout (works around nginx `/logout` intercept)
  - `biber` → `administrator` direct message flow using isolated browser contexts
- `playwright.env.j2`: injects OIDC credentials, Mattermost URL, and user credentials for the test runner
- `tasks/01_setup.yml`: creates and configures `administrator` and `biber` users, adds them to the team, and links GitLab SSO auth via LDAP `uidNumber`
- `env.j2`: adds `MM_EXPERIMENTALSETTINGS_DISABLELANDINGPAGE=true` to prevent `/landing` SPA redirect in fresh browser contexts
- `README.md`: fix H1 heading so the dashboard card renders the "Explore Mattermost" link correctly

---

## File Checklist

| Check | Item |
|---|---|
| [x] | `README.md` |
| [ ] | `meta/main.yml` |
| [ ] | `vars/main.yml` |
| [ ] | `config/main.yml` |
| [ ] | `schema/main.yml` |
| [ ] | `tasks/main.yml` |
| [ ] | `templates/compose.yml.j2` |
| [x] | `templates/env.j2` |
| [ ] | `users/main.yml` |
| [ ] | `files/Dockerfile` |
| [x] | `templates/playwright.env.j2` |
| [x] | `files/playwright.spec.js` |

---

## Local Validation

* [x] Playwright test run documented
* [x] Login flow tested (SSO via GitLab OAuth2)
* [x] Logout flow tested (API logout)

---

## Security Impact

* [x] No relevant security impact

---

## Review Focus

* `tasks/01_setup.yml`: user creation and LDAP `uidNumber` binding for SSO — verify idempotency
* `playwright.spec.js`: SSO workaround via direct OAuth2 endpoint due to missing Mattermost v11.5.1 client config key

---

## Definition of Done (DoD)

* [x] The implementation follows the Definition of Done, and the contribution guidelines in [CONTRIBUTING.md](../../CONTRIBUTING.md) were considered and applied during implementation.

---

## Additional Notes

Closes #538.