### PR TITLE
fix(ci): mirror images for same-repo PRs directly from entry-pull-request.yml

### DIFF
--- a/.github/workflows/entry-pull-request-change.yml
+++ b/.github/workflows/entry-pull-request-change.yml
@@ -86,6 +86,17 @@ jobs:
     with:
       distros: "arch debian ubuntu fedora centos"
 
+  images-mirror-missing:
+    needs:
+      - detect-pr-scope
+      - validate-pr-branch-prefix
+    if: ${{ github.event_name == 'pull_request' && needs.detect-pr-scope.outputs.run_ci_orchestrator == 'true' }}
+    uses: ./.github/workflows/images-mirror-missing.yml
+    with:
+      concurrency_channel: pr-mirror-producer
+      concurrency_key: pr-${{ github.event.pull_request.number }}
+    secrets: inherit
+
   prepare-fork-merge-ref:
     needs:
       - detect-pr-scope


### PR DESCRIPTION
## Summary

New Docker images added in same-repo PR branches were never mirrored to GHCR because the mirror job only ran inside `ci-orchestrator` (2 levels of `workflow_call` nesting), where `github.event.pull_request.head.repo.full_name` is not propagated and evaluates to `null`. This caused every same-repo PR to be treated as a fork PR, triggering the wait step instead of the mirror step.

---

## Template Type

* [ ] **Feature** - Adds or extends CI/CD functionality
* [x] **Fix** - Repairs broken or incorrect CI/CD behavior

---

## Affected Components

* Workflow file(s): `.github/workflows/entry-pull-request.yml`
* Related scripts, actions, jobs, or images: `images-mirror-missing.yml`, `ci-orchestrator.yml`
* Fork, PR, release, or scheduled paths affected: same-repo `pull_request` path only — fork path unchanged

---

## Change Type

* [ ] **Major** - Breaking change
* [ ] **Minor** - New backwards-compatible feature
* [x] **Patch** - Small improvement or compatible adjustment

---

## Change Details

**Problem:** `github.event.pull_request.head.repo.full_name` is not propagated beyond one level of `workflow_call` nesting. At level 2 it evaluates to `null`, and `null != github.repository` is `true` in GHA expressions — making every same-repo PR look like a fork PR and triggering the wait step instead of the mirror step inside `images-mirror-missing.yml`.

**Solution:** Add a direct `images-mirror-missing` job to `entry-pull-request.yml` for same-repo `pull_request` events (same condition as `ci-orchestrator`). Running at level 1, the github context is fully available and the fork check evaluates correctly — mirror step runs. The existing call inside `ci-orchestrator.yml` stays unchanged; it correctly acts as a wait and succeeds once the level-1 job has mirrored the images.

**Alternatives considered:** Adding an explicit `is_fork_pr` boolean input to `images-mirror-missing.yml` and resolving fork detection in `ci-orchestrator.yml` before passing it down. Rejected as more invasive — this approach requires no changes to `images-mirror-missing.yml` or `ci-orchestrator.yml`.

---

## Validation

* [ ] Local or targeted script validation performed
* [ ] Workflow run in fork or equivalent validation
* [ ] Relevant logs or run links attached
* [ ] Failure-path or retry behavior checked

Validation: open this PR → CI run → confirm `images-mirror-missing` job appears and `Mirror images to GHCR` step executes (not `Wait for mirrored images`). After merge, re-run CI on PRs that added new images (e.g. #112, #129) to confirm end-to-end mirroring.

---

## Security Impact

* [x] No relevant security impact

Fork path is completely unchanged. The new job uses the same `secrets: inherit` and `packages: write` permissions already present on `entry-pull-request.yml`.

---

## Review Focus

* `entry-pull-request.yml`: confirm the new job condition (`github.event_name == 'pull_request' && run_ci_orchestrator == 'true'`) is correct and does not trigger for fork PRs or `pull_request_target` events
* Concurrency: `concurrency_channel: pr-mirror-producer` + `concurrency_key: pr-<number>` scopes the job per PR and avoids conflicts with the orchestrator-internal call (`ci-orchestrator-mirror-consumer`)

---

## Definition of Done (DoD)

* [x] The implementation follows the Definition of Done, and the contribution guidelines in [CONTRIBUTING.md](../../CONTRIBUTING.md) were considered and applied during implementation.

---

## Additional Notes

Closes #131. Affects open PRs #112 (web-app-fider) and #129 (web-app-prometheus) which both added new Docker images that were never mirrored due to this bug.
