### PR TITLE
fix(web-app-mailu): restore WSL2/DinD DNS forwarding via MAILU_UNBOUND_FORWARD_DNS

### DIFF
--- a/roles/web-app-mailu/templates/unbound.conf.j2
+++ b/roles/web-app-mailu/templates/unbound.conf.j2
@@ -26,3 +26,13 @@ server:
 remote-control:
   control-enable: yes
   control-interface: /run/unbound.control.sock
+{% if MAILU_UNBOUND_FORWARD_DNS | bool %}
+
+# WSL2/DinD: iterative resolution via root-hints is not supported in nested
+# Docker. Forward all queries to public resolvers instead.
+# Enable by setting MAILU_UNBOUND_FORWARD_DNS: true in your inventory.
+forward-zone:
+  name: "."
+  forward-addr: 1.1.1.1
+  forward-addr: 8.8.8.8
+{% endif %}

--- a/roles/web-app-mailu/vars/main.yml
+++ b/roles/web-app-mailu/vars/main.yml
@@ -65,6 +65,12 @@ MAILU_DMARC_RUF:                      "{{ lookup('config', application_id, 'user
 MAILU_DKIM_KEY_FILE:                  "{{ MAILU_DOMAIN }}.dkim.key"
 MAILU_DKIM_KEY_PATH:                  "/dkim/{{ MAILU_DKIM_KEY_FILE }}"
 
+## Unbound
+# Set to true in WSL2/DinD environments where iterative DNS resolution via
+# root-hints is not supported. Forwards all queries to public resolvers instead.
+# On bare-metal this must remain false to preserve DNSSEC validation.
+MAILU_UNBOUND_FORWARD_DNS:            "{{ 'microsoft' in lookup('file', '/proc/version') | lower }}"
+
 ## Rspamd
 MAILU_UNBOUND_CONF_FILE:              "{{ [ MAILU_OVERRIDES_DIR, 'unbound/unbound.conf' ] | path_join }}"
 MAILU_RSPAMD_HOST_DIR:                "{{ [ MAILU_OVERRIDES_DIR, 'rspamd' ] | path_join }}"


### PR DESCRIPTION
## Summary

Restores DNS forwarding for WSL2/DinD environments in `web-app-mailu` without affecting bare-metal DNSSEC resolution. PR #126 removed the `forward-zone` block from `unbound.conf.j2` entirely, which broke DNS inside the Mailu Unbound resolver when running on WSL2 or Docker-in-Docker. This fix introduces `MAILU_UNBOUND_FORWARD_DNS`, auto-detected from `/proc/version`, so bare-metal and CI remain on Kevin's iterative DNSSEC approach while WSL2 automatically enables forwarding.

---

## Template Type

* [ ] **Feature** - Adds or extends server functionality
* [x] **Fix** - Repairs broken or incorrect server behavior

---

## Affected Roles and Services

* Primary `web-*` role(s): `web-app-mailu`
* Related `web-svc-*`, `sys-front-*`, `svc-db-*`, auth, mail, proxy, or storage role(s): Unbound DNS resolver inside Mailu

## Preferred Integrations

* [ ] Dashboard
* [ ] Matomo
* [ ] OIDC
* [ ] LDAP
* [ ] Logout

---

## Change Type

* [ ] **Major** - Breaking change
* [ ] **Minor** - New backwards-compatible feature
* [x] **Patch** - Small improvement or compatible adjustment

---

## Change Details

**Problem:** PR #126 removed the `forward-zone` block from `unbound.conf.j2` to fix iterative DNSSEC resolution on bare-metal. However, the block was previously guarded by `{% if DOCKER_IN_CONTAINER %}`. Without it, Unbound inside the Mailu container cannot resolve external hostnames on WSL2/DinD because iterative resolution via root-hints is not supported in nested Docker.

**Solution:** Introduce `MAILU_UNBOUND_FORWARD_DNS` (default `false`) in `vars/main.yml`, auto-detected via:

```yaml
MAILU_UNBOUND_FORWARD_DNS: "{{ 'microsoft' in lookup('file', '/proc/version') | lower }}"
```

- **Bare-metal / CI**: `/proc/version` contains no "microsoft" → `false` → no `forward-zone` → Kevin's iterative DNSSEC works ✓
- **WSL2**: `/proc/version` contains "microsoft" → `true` → `forward-zone` to `1.1.1.1`/`8.8.8.8` → DNS resolves ✓

The variable can also be overridden manually in the inventory if needed.

**Alternatives considered:** Using `DOCKER_IN_CONTAINER` as the condition — rejected because it is also `true` in Kevin's CI Docker runners, which would re-break DNSSEC there.

---

## File Checklist

| Check | Item | When to include | Purpose |
|---|---|---|---|
| [ ] | `README.md` | Usually | Documents role-specific usage, setup notes, and contributor context. |
| [ ] | `meta/main.yml` | Usually | Declares role metadata and dependencies. |
| [x] | `vars/main.yml` | Usually | Defines the shared fixed role variables as the main source of truth. |
| [ ] | `config/main.yml` | Usually | Defines the configurable app-facing settings for the role. |
| [ ] | `schema/main.yml` | When schema validation is used | Describes and validates the supported configuration surface. |
| [ ] | `tasks/main.yml` | Usually | Acts as the role entry point and includes the main task flow. |
| [ ] | `templates/compose.yml.j2` | For containerized app roles | Defines the service, volume, environment, port, and network wiring. |
| [ ] | `templates/env.j2` | When the app uses environment files | Renders the app environment configuration. |
| [x] | `templates/unbound.conf.j2` | — | Conditional `forward-zone` block behind `MAILU_UNBOUND_FORWARD_DNS` |
| [ ] | `users/main.yml` | When the role bootstraps users or identities | Defines user bootstrap or role-specific user management data. |
| [ ] | `templates/playwright.env.j2` | When Playwright coverage is included | Configures the Playwright test environment. |
| [ ] | `files/playwright.spec.js` | When Playwright coverage is included | Defines the Playwright login and logout test flow. |

---

## Local Validation

* [x] Deployment target and distro documented
* [ ] Playwright test run documented
* [ ] Login flow tested
* [ ] Logout flow tested

Validated on WSL2 (Debian DinD via `APPS=web-app-mailu make deploy-fresh-kept-apps`). Generated `unbound.conf` confirmed to contain the `forward-zone` block, confirming WSL2 auto-detection fired correctly.

---

## Security Impact

* [x] No relevant security impact

Forwarding only activates on WSL2 where iterative DNSSEC resolution is not functional anyway. Bare-metal and CI are unaffected.

---

## Review Focus

* `vars/main.yml`: `MAILU_UNBOUND_FORWARD_DNS` auto-detection via `/proc/version` — confirm reliable across all supported distros
* `unbound.conf.j2`: confirm `forward-zone` block does not interfere with bare-metal DNSSEC when `MAILU_UNBOUND_FORWARD_DNS` is `false`

---

## Definition of Done (DoD)

* [x] The implementation follows the Definition of Done, and the contribution guidelines in [CONTRIBUTING.md](../../CONTRIBUTING.md) were considered and applied during implementation.

---

## Additional Notes

Closes #133. The previous approach using `DOCKER_IN_CONTAINER` was too broad — this replaces it with WSL2-specific detection via `/proc/version`.
