### PR TITLE
fix(web-app-prometheus): add missing shared:true to oauth2, logout, dashboard and css services

### DIFF
--- a/roles/web-app-prometheus/config/main.yml
+++ b/roles/web-app-prometheus/config/main.yml
@@ -18,6 +18,7 @@ compose:
       enabled:                    false
     oauth2:
       enabled:                    true
+      shared:                     true
       origin:
         host:                     "application"
         port:                     "9090"
@@ -25,8 +26,10 @@ compose:
         - "{{ [RBAC.GROUP.NAME, 'web-app-prometheus-administrator'] | path_join }}"
     logout:
       enabled:                    true
+      shared:                     true
     dashboard:
       enabled:                    true
+      shared:                     true
     matomo:
       enabled:                    true
       shared:                     true
@@ -36,6 +39,7 @@ compose:
       enabled:                    false
     css:
       enabled:                    true
+      shared:                     true
     prometheus:
       image:                      "prom/prometheus"
       version:                    "v3.2.1"


### PR DESCRIPTION
## Summary

Fixes `make test` failure introduced by Kevin's `test_service_shared_consistency` check (commit `ec2b513bd`, 2026-03-30). The `web-app-prometheus` role was missing `shared: true` on four enabled shared services in `config/main.yml`.

---

## Template Type

* [ ] **Feature** - Adds or extends server functionality
* [x] **Fix** - Repairs broken or incorrect server behavior

---

## Affected Roles and Services

* Primary `web-*` role(s): `web-app-prometheus`
* Related `web-svc-*`, `sys-front-*`, `svc-db-*`, auth, mail, proxy, or storage role(s): oauth2-proxy, logout, dashboard, css (shared services)

## Preferred Integrations

* [ ] Dashboard
* [ ] Matomo
* [ ] OIDC
* [ ] LDAP
* [ ] Logout

---

## Change Type

* [ ] **Major** - Breaking change
* [ ] **Minor** - New backwards-compatible feature
* [x] **Patch** - Small improvement or compatible adjustment

---

## Change Details

**Problem:** PR #129 (`web-app-prometheus`) was merged before Kevin added the `test_service_shared_consistency` integration test. That test enforces that any enabled shared service must declare `shared: true`. The prometheus role had `enabled: true` on `oauth2`, `logout`, `dashboard`, and `css` but was missing `shared: true` on all four, causing `make test` to fail.

**Solution:** Add `shared: true` to the four affected services, consistent with how `matomo` is already declared in the same file.

---

## File Checklist

| Check | Item | When to include | Purpose |
|---|---|---|---|
| [ ] | `README.md` | Usually | Documents role-specific usage, setup notes, and contributor context. |
| [ ] | `meta/main.yml` | Usually | Declares role metadata and dependencies. |
| [ ] | `vars/main.yml` | Usually | Defines the shared fixed role variables as the main source of truth. |
| [x] | `config/main.yml` | Usually | Defines the configurable app-facing settings for the role. |
| [ ] | `schema/main.yml` | When schema validation is used | Describes and validates the supported configuration surface. |
| [ ] | `tasks/main.yml` | Usually | Acts as the role entry point and includes the main task flow. |
| [ ] | `templates/compose.yml.j2` | For containerized app roles | Defines the service, volume, environment, port, and network wiring. |
| [ ] | `templates/env.j2` | When the app uses environment files | Renders the app environment configuration. |
| [ ] | `templates/playwright.env.j2` | When Playwright coverage is included | Configures the Playwright test environment. |
| [ ] | `files/playwright.spec.js` | When Playwright coverage is included | Defines the Playwright login and logout test flow. |

---

## Local Validation

* [x] Deployment target and distro documented
* [ ] Playwright test run documented
* [ ] Login flow tested
* [ ] Logout flow tested

`make test` run locally — all 131 tests pass (skipped=223) after applying this fix. Confirmed on WSL2.

---

## Security Impact

* [x] No relevant security impact

---

## Review Focus

* `config/main.yml`: confirm `shared: true` is correct for all four services (`oauth2`, `logout`, `dashboard`, `css`) — reference: `matomo` in the same file already has it

---

## Definition of Done (DoD)

* [x] The implementation follows the Definition of Done, and the contribution guidelines in [CONTRIBUTING.md](../../CONTRIBUTING.md) were considered and applied during implementation.

---

## Additional Notes

Closes #135. This is a follow-up to PR #129 — the test that catches this did not exist when that PR was merged.