### PR TITLE
Potential fix for code scanning alert no. 261: Useless assignment to local variable

### DIFF
--- a/roles/web-app-bigbluebutton/files/greenlight_ensure_admin.rb
+++ b/roles/web-app-bigbluebutton/files/greenlight_ensure_admin.rb
@@ -56,7 +56,6 @@ if user
   if user.respond_to?(:role=) && user.respond_to?(:role_id)
     if user.role_id != admin_role.id
       user.role = admin_role
-      changed = true
     end
   end
 


### PR DESCRIPTION
Potential fix for [https://github.com/infinito-nexus/core/security/code-scanning/261](https://github.com/infinito-nexus/core/security/code-scanning/261)

The best fix is to remove the redundant `changed = true` inside the role update block (line 59), because `changed` is already guaranteed to be set to `true` later in the same branch when password is always reset (line 66). This preserves existing functionality exactly while eliminating the useless assignment flagged by CodeQL.

Edit only `roles/web-app-bigbluebutton/files/greenlight_ensure_admin.rb`, in the `if user` branch under the `role` update check. No imports, new methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
