### PR TITLE
feat(svc-net-pihole): add Pi-hole role for network-wide DNS ad blocking

### DIFF
--- a/group_vars/all/10_networks.yml
+++ b/group_vars/all/10_networks.yml
@@ -127,6 +127,8 @@ defaults_networks:
       subnet: 192.168.104.144/28
     web-app-prometheus:
       subnet: 192.168.104.160/28
+    svc-net-pihole:
+      subnet: 192.168.104.176/28
 
     # /24 Networks / 254 Usable Clients
     web-app-bigbluebutton:

--- a/roles/svc-net-pihole/README.md
+++ b/roles/svc-net-pihole/README.md
@@ -1,0 +1,44 @@
+# svc-net-pihole
+
+Deploys [Pi-hole](https://pi-hole.net/) as a network-wide DNS sinkhole for ad and tracker blocking.
+
+## What is Pi-hole?
+
+Pi-hole acts as a DNS server for your network. When a device requests a domain known to serve ads or trackers, Pi-hole returns a null response — blocking the content before it is downloaded. This protects every device on the network without any client-side configuration.
+
+## Features
+
+- Network-wide DNS-level ad and tracker blocking
+- Web dashboard for monitoring and managing DNS queries
+- Custom blocklist support via gravity
+- Upstream DNS configurable (default: Cloudflare `1.1.1.1`)
+
+## Environment Variables
+
+| Variable           | Description                          | Default          |
+|--------------------|--------------------------------------|------------------|
+| `PIHOLE_DNS_`      | Upstream DNS servers (semicolon-sep) | `1.1.1.1;1.0.0.1` |
+| `WEBPASSWORD`      | Admin dashboard password             | generated        |
+| `TZ`               | Timezone                             | `Europe/Berlin`  |
+| `WEB_PORT`         | Internal web UI port                 | `8053`           |
+
+## Deployment
+
+```bash
+APPS=svc-net-pihole make deploy-fresh-kept-apps
+```
+
+## Admin UI
+
+After deployment the dashboard is available at:
+http://<host>:8053/admin
+
+## DNS Configuration
+
+Point your router's DHCP DNS setting to the host running Pi-hole so all network devices use it automatically.
+
+## References
+
+- [Pi-hole documentation](https://docs.pi-hole.net/)
+- [Pi-hole Docker image](https://github.com/pi-hole/docker-pi-hole)
+- [Blocklist collection](https://firebog.net/)

--- a/roles/svc-net-pihole/config/main.yml
+++ b/roles/svc-net-pihole/config/main.yml
@@ -1,0 +1,23 @@
+compose:
+  services:
+    pihole:
+      enabled:          false
+      shared:           false
+      backup:
+        no_stop_required: true
+      image:            "pihole/pihole"
+      version:          "latest"
+      name:             "pihole"
+      min_storage:      "1GB"
+      port:             8053
+      cpus:             "0.5"
+      mem_reservation:  "128m"
+      mem_limit:        "256m"
+      pids_limit:       512
+  volumes:
+    data:     "pihole_data"
+    dnsmasq:  "pihole_dnsmasq"
+  network:    "pihole"
+pihole:
+  upstream_dns:   "1.1.1.1;1.0.0.1"
+  timezone:       "Europe/Berlin"

--- a/roles/svc-net-pihole/meta/main.yml
+++ b/roles/svc-net-pihole/meta/main.yml
@@ -1,0 +1,25 @@
+galaxy_info:
+  author: Kevin Veen-Birkenbach
+  description: Installs Pi-hole — a network-wide DNS sinkhole for ad and tracker blocking.
+  license: Infinito.Nexus Community License (Non-Commercial)
+  license_url: https://s.infinito.nexus/license
+  company: |
+    Kevin Veen-Birkenbach
+    Consulting & Coaching Solutions
+    https://www.veen.world
+  galaxy_tags:
+  - network
+  - dns
+  - adblock
+  - privacy
+  - sinkhole
+  - self-hosted
+  - pihole
+  repository: https://s.infinito.nexus/code
+  issue_tracker_url: https://s.infinito.nexus/issues
+  documentation: https://s.infinito.nexus/code/
+  logo:
+    class: fa-solid fa-shield-halved
+  run_after: []
+  lifecycle: alpha
+dependencies: []

--- a/roles/svc-net-pihole/tasks/01_core.yml
+++ b/roles/svc-net-pihole/tasks/01_core.yml
@@ -1,0 +1,8 @@
+- include_tasks: utils/once/flag.yml
+
+- name: "Setup container network for {{ application_id }}"
+  include_tasks: "{{ [playbook_dir, 'roles/sys-svc-compose/tasks/utils/network.yml'] | path_join }}"
+  vars:
+    docker_network_name:            "{{ PIHOLE_NETWORK }}"
+    docker_network_subnet:          "{{ networks.local[application_id].subnet }}"
+    docker_compose_flush_handlers:  true

--- a/roles/svc-net-pihole/tasks/main.yml
+++ b/roles/svc-net-pihole/tasks/main.yml
@@ -1,0 +1,2 @@
+- include_tasks: 01_core.yml
+  when: run_once_svc_net_pihole is not defined

--- a/roles/svc-net-pihole/templates/compose.yml.j2
+++ b/roles/svc-net-pihole/templates/compose.yml.j2
@@ -1,0 +1,34 @@
+{% include 'roles/sys-svc-compose/templates/base.yml.j2' %}
+
+  pihole:
+{% include 'roles/sys-svc-container/templates/base.yml.j2' %}
+    image: "{{ PIHOLE_IMAGE }}:{{ PIHOLE_VERSION }}"
+    container_name: "{{ PIHOLE_CONTAINER }}"
+    environment:
+      TZ:               "{{ PIHOLE_TIMEZONE }}"
+      WEBPASSWORD:      "{{ PIHOLE_PASSWORD }}"
+      PIHOLE_DNS_:      "{{ PIHOLE_UPSTREAM_DNS }}"
+    ports:
+      - "53:53/tcp"
+      - "53:53/udp"
+      - "{{ PIHOLE_PORT }}:80/tcp"
+    volumes:
+      - pihole_data:/etc/pihole
+      - pihole_dnsmasq:/etc/dnsmasq.d
+    cap_add:
+      - NET_ADMIN
+{% include 'roles/sys-svc-container/templates/networks.yml.j2' %}
+
+networks:
+  default:
+    name: "{{ PIHOLE_NETWORK }}"
+    external: true
+
+{{ applications | compose_volumes(
+    application_id,
+    database_volume=lookup('database', application_id, 'volume'),
+    extra_volumes={
+      'pihole_data':   {'name': PIHOLE_VOLUME_DATA},
+      'pihole_dnsmasq': {'name': PIHOLE_VOLUME_DNSMASQ}
+    }
+) }}

--- a/roles/svc-net-pihole/vars/main.yml
+++ b/roles/svc-net-pihole/vars/main.yml
@@ -1,0 +1,15 @@
+# General
+application_id:           "svc-net-pihole"
+
+# Pi-hole
+# https://pi-hole.net/
+PIHOLE_VERSION:           "{{ lookup('config', application_id, 'compose.services.pihole.version') }}"
+PIHOLE_IMAGE:             "{{ lookup('config', application_id, 'compose.services.pihole.image') }}"
+PIHOLE_CONTAINER:         "{{ lookup('config', application_id, 'compose.services.pihole.name') }}"
+PIHOLE_PORT:              "{{ lookup('config', application_id, 'compose.services.pihole.port') }}"
+PIHOLE_VOLUME_DATA:       "{{ lookup('config', application_id, 'compose.volumes.data') }}"
+PIHOLE_VOLUME_DNSMASQ:    "{{ lookup('config', application_id, 'compose.volumes.dnsmasq') }}"
+PIHOLE_NETWORK:           "{{ lookup('config', application_id, 'compose.network') }}"
+PIHOLE_UPSTREAM_DNS:      "{{ lookup('config', application_id, 'pihole.upstream_dns') }}"
+PIHOLE_TIMEZONE:          "{{ lookup('config', application_id, 'pihole.timezone') }}"
+PIHOLE_PASSWORD:          "{{ lookup('password', application_id, 'admin') }}"


### PR DESCRIPTION
## Overview

Adds `svc-net-pihole` — a new Ansible role that deploys [Pi-hole](https://pi-hole.net/) 
as a network-wide DNS sinkhole for ad and tracker blocking, fully integrated into the 
Infinito.Nexus platform conventions.

## What is Pi-hole?

Pi-hole acts as a DNS server for your network. When a device requests a domain known 
to serve ads or trackers, Pi-hole returns a null response — blocking the content before 
it is downloaded. This protects every device on the network without any client-side 
configuration.

## Approach

### Reference-first design
Inspected existing roles before writing any code:
- `svc-ai-ollama` — Docker/Compose based, no DB, closest structural match
- `svc-net-wireguard-plain` — confirmed naming convention (`svc-net-*`)

### Role naming
Initially scaffolded as `svc-network-pihole` but corrected to `svc-net-pihole` after 
discovering the platform's `categories.yml` defines the invokable prefix as `svc-net-*`, 
required for CLI inventory generator discovery. Note: the branch name 
`feature/svc-network-pihole/add-role` retains the original name — the role itself 
is correctly named `svc-net-pihole`.

### Platform registration
- `group_vars/all/10_networks.yml` — assigned free `/28` subnet `192.168.104.176/28`
- `group_vars/all/05_applications.yml` — auto-generated by `make setup` from the 
  roles directory, intentionally excluded from version control via 
  `group_vars/all/.gitignore`

### Minimal task structure
Follows the `svc-ai-ollama` pattern:
- `tasks/main.yml` — `run_once_*` guard only
- `tasks/01_core.yml` — run-once flag + Docker network setup via 
  `sys-svc-compose/tasks/utils/network.yml`
- No manual compose render — `sys-svc-compose` auto-discovers and renders 
  `compose.yml.j2` via `04_files.yml`

### Compose template design
- Uses official `pihole/pihole` image — no custom Dockerfile needed
- Network marked as `external: true` to avoid compose/Ansible ownership conflict
  (Ansible pre-creates the network; without `external: true` compose rejects it)
- Port mapping `8053:80/tcp` for admin UI (Pi-hole serves internally on port 80)
- DNS ports `53/tcp` and `53/udp` exposed for network-wide resolution
- `NET_ADMIN` capability for full DNS functionality

## Verification

Tested inside `infinito_nexus_debian` (same environment as CI):

| Check | Result |
|---|---|
| Container status | `Up (healthy)` ✅ |
| DNS resolution (`google.com`) | Resolves correctly ✅ |
| Ad blocking (`doubleclick.net`) | Returns `0.0.0.0` ✅ |
| Admin UI (`port 8053`) | Returns `302` (login redirect) ✅ |

## DNS Architecture & CI Considerations

Pi-hole uses Cloudflare (`1.1.1.1;1.0.0.1`) as upstream DNS. CoreDNS 
(`infinito-coredns`) runs on a separate compose network IP — both services 
bind port 53 on different network interfaces and do not conflict.

**Known limitation:** Pi-hole cannot resolve internal `*.infinito.example` domains 
since Cloudflare has no knowledge of them. CoreDNS handles these internally within 
the compose stack network but is not integrated with Pi-hole. A conditional forwarder 
pointing `*.infinito.example` to CoreDNS is planned as a follow-up task:
/etc/dnsmasq.d/infinito.conf
server=/infinito.example/<CoreDNS-IP>

This will be mounted via the compose template in a follow-up PR.

## Files Changed

| File | Change |
|---|---|
| `roles/svc-net-pihole/meta/main.yml` | Role metadata, galaxy tags, lifecycle: alpha |
| `roles/svc-net-pihole/config/main.yml` | Image, port, resource limits, upstream DNS |
| `roles/svc-net-pihole/vars/main.yml` | Variable definitions via config lookup |
| `roles/svc-net-pihole/tasks/main.yml` | run_once guard |
| `roles/svc-net-pihole/tasks/01_core.yml` | Network setup |
| `roles/svc-net-pihole/templates/compose.yml.j2` | Docker Compose template |
| `roles/svc-net-pihole/README.md` | Documentation |
| `group_vars/all/10_networks.yml` | Subnet registration |