### PR TITLE
fix(mattermost): inject SSO button via JS for v11 Team Edition

### DIFF
--- a/roles/web-app-mattermost/files/playwright.spec.js
+++ b/roles/web-app-mattermost/files/playwright.spec.js
@@ -60,12 +60,22 @@ async function performOidcLogin(frame, username, password) {
   await signInButton.click();
 }
 
-// Navigate directly to the Mattermost GitLab OAuth2 login endpoint.
-// This bypasses the login page button rendering (which requires EnableSignInWithGitLab
-// in the client config) and also bypasses the /landing app-selection dialog that
-// Mattermost shows for fresh browser contexts in v11+.
+// Navigate to the Mattermost login page and click the SSO button injected by javascript.js.j2.
+// Mattermost v11 redirects fresh browser contexts (no cookies) from /login to /landing before
+// the login form renders. We detect that redirect and navigate back to /login so the form
+// and the injected button can appear.
 async function startMattermostSsoFlow(page, baseUrl) {
-  await page.goto(`${baseUrl.replace(/\/$/, "")}/oauth/gitlab/login`);
+  const base = baseUrl.replace(/\/$/, "");
+  await page.goto(`${base}/login`);
+
+  // If Mattermost redirected to /landing, navigate back to /login
+  if (page.url().includes("/landing")) {
+    await page.goto(`${base}/login`);
+  }
+
+  const ssoButton = page.locator("a[href='/oauth/gitlab/login']");
+  await ssoButton.waitFor({ state: "visible", timeout: 30_000 });
+  await ssoButton.click();
 }
 
 // Dismiss Mattermost onboarding modals/tips that may appear after first SSO login.

--- a/roles/web-app-mattermost/templates/javascript.js.j2
+++ b/roles/web-app-mattermost/templates/javascript.js.j2
@@ -1,11 +1,30 @@
 window.addEventListener("DOMContentLoaded", function () {
+    var injected = false;
+
     var observer = new MutationObserver(function () {
-        document.querySelectorAll("a[href*='/oauth/gitlab/'], button").forEach(function (el) {
+        // Rename if Mattermost ever renders the GitLab button natively
+        document.querySelectorAll("a[href*='/oauth/gitlab/']").forEach(function (el) {
             if (el.textContent.trim() === "GitLab") {
                 el.textContent = "SSO with Infinito.Nexus";
-                observer.disconnect();
             }
         });
+
+        // Inject SSO button when login form is present but no native SSO button rendered
+        if (injected) return;
+        if (!document.getElementById("input_loginId")) return;
+        if (document.querySelector("a[href*='/oauth/gitlab/']")) return;
+
+        var btn = document.getElementById("saveSetting");
+        if (!btn) return;
+
+        var a = document.createElement("a");
+        a.href = "/oauth/gitlab/login";
+        a.textContent = "SSO with Infinito.Nexus";
+        a.className = "btn btn-primary login-body-card-form-button-submit large";
+        a.style.cssText = "display:flex;align-items:center;justify-content:center;width:100%;box-sizing:border-box;margin:20px 0 0 0;";
+        btn.parentNode.insertBefore(a, btn.nextSibling);
+        injected = true;
     });
+
     observer.observe(document.body, { childList: true, subtree: true });
 });


### PR DESCRIPTION
## Summary

- Mattermost v11 Team Edition does not render the GitLab SSO button natively: `EnableSignInWithGitLab` is absent from the client config API even when `MM_GITLABSETTINGS_ENABLE=true`, so the React frontend never renders the button
- Extends `javascript.js.j2` to inject an `<a href="/oauth/gitlab/login">SSO with Infinito.Nexus</a>` button via `MutationObserver` when the login form is detected (`#input_loginId` present) but no native SSO anchor exists
- Button uses Mattermost's own CSS classes (`btn btn-primary login-body-card-form-button-submit large`) plus explicit flex/width/margin styles to match the native "Log in" button alignment exactly
- Updates `playwright.spec.js`: `startMattermostSsoFlow` now navigates to `/login`, handles the v11 `/landing` redirect for fresh browser contexts, then clicks the injected button — proving both the JS injection and the OAuth2 backend in a single flow

## Test plan

- [x] Deploy `web-app-mattermost` and hard-refresh `/login` — "SSO with Infinito.Nexus" button appears below "Log in", aligned and spaced correctly
- [x] Click the button — redirects to Keycloak, SSO login completes, lands on Mattermost channel view
- [x] Email/password login still works (untouched)
- [x] Playwright E2E passes: `make test-e2e-playwright -e TEST_E2E_PLAYWRIGHT_ONLY_ROLES='["web-app-mattermost"]'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)