### PR TITLE
Potential fix for code scanning alert no. 278: Empty except

### DIFF
--- a/tests/lint/ansible/roles/test_compose_resource_limits.py
+++ b/tests/lint/ansible/roles/test_compose_resource_limits.py
@@ -73,7 +73,9 @@ def _find_service_line(config_path: Path, service_name: str) -> int:
             if pattern.match(raw):
                 return i
     except OSError:
-        pass
+        # Best-effort lookup only: if the file can't be read, keep linting and
+        # point the annotation at line 1 as a safe fallback.
+        return 1
     return 1
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/infinito-nexus/core/security/code-scanning/278](https://github.com/infinito-nexus/core/security/code-scanning/278)

Keep current functionality (best-effort parsing + fallback line `1`) but replace the empty `except` body with an explicit, documented fallback.  
Best fix in this snippet: add an explanatory comment in the `except OSError:` block to document intentional suppression and why it is safe in this context.

Edit in `tests/lint/ansible/roles/test_compose_resource_limits.py`, inside `_find_service_line` around lines 75–76:
- Replace `pass` with a comment explaining that I/O failures are non-fatal for lint annotations and fallback to line 1 is intentional.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
