### PR TITLE
Potential fix for code scanning alert no. 277: Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/tests/integration/services/test_frontend_spot.py
+++ b/tests/integration/services/test_frontend_spot.py
@@ -24,6 +24,7 @@ class TestFrontendServiceSpot(unittest.TestCase):
             if entry["role"] == role_name:
                 return index
         self.fail(f"Role {role_name} not found in ordered service registry")
+        return -1
 
     def test_bucket_order_is_monotonic(self):
         bucket_order = {


### PR DESCRIPTION
Potential fix for [https://github.com/infinito-nexus/core/security/code-scanning/277](https://github.com/infinito-nexus/core/security/code-scanning/277)

Add an explicit return after `self.fail(...)` in `_index` so all control-flow paths are explicit and consistent with the function’s return behavior.

Best fix (without changing functionality): in `tests/integration/services/test_frontend_spot.py`, inside `_index`, keep `self.fail(...)` as-is and add `return -1` immediately after it. This value is unreachable in normal execution because `self.fail` raises, but it satisfies static analysis and removes mixed explicit/implicit return paths.

No imports, new methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
