### PR TITLE
Potential fix for code scanning alert no. 274: Empty except

### DIFF
--- a/roles/web-app-odoo/files/addons/auth_oauth_https/controllers/main.py
+++ b/roles/web-app-odoo/files/addons/auth_oauth_https/controllers/main.py
@@ -2,10 +2,13 @@
 # Part of Infinito.Nexus. See LICENSE file for full copyright and licensing details.
 
 import json
+import logging
 import werkzeug.urls
 
 from odoo.http import request
 from odoo.addons.auth_oauth.controllers.main import OAuthLogin
+
+_logger = logging.getLogger(__name__)
 
 
 class OAuthLoginHTTPS(OAuthLogin):
@@ -37,7 +40,9 @@ class OAuthLoginHTTPS(OAuthLogin):
                     base_url += "/"
                 return base_url
         except Exception:
-            pass
+            _logger.exception(
+                "Failed to read 'web.base.url' from ir.config_parameter; falling back to request URL root."
+            )
         # Fallback to standard behavior
         return request.httprequest.url_root
 


### PR DESCRIPTION
Potential fix for [https://github.com/infinito-nexus/core/security/code-scanning/274](https://github.com/infinito-nexus/core/security/code-scanning/274)

General fix: replace empty `except` blocks with explicit handling that either logs the exception (and safely continues) or re-raises a more specific error. Prefer narrowing exception types where practical.

Best fix here without changing behavior: in `roles/web-app-odoo/files/addons/auth_oauth_https/controllers/main.py`, update `_get_base_url` so the `except Exception` block logs the exception and then falls back as before. This preserves current functionality (fallback to `request.httprequest.url_root`) while eliminating silent failure.

Changes needed:
- Add Python standard library import: `import logging`.
- Define module logger: `_logger = logging.getLogger(__name__)`.
- Replace the empty except body with `_logger.exception(...)` (or warning with exception info).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
