### PR TITLE
Potential fix for code scanning alert no. 280: Unused global variable

### DIFF
--- a/utils/docker/version_updater.py
+++ b/utils/docker/version_updater.py
@@ -19,7 +19,6 @@ from utils.docker.image.ref import (
 )
 
 _SEMVER_CORE = r"v?\d+(?:\.\d+){0,3}"
-_SEMVER_RE = re.compile(rf"^{_SEMVER_CORE}$")
 # Tags that extend a semver with a `-<flavor>` suffix, e.g. the Docker
 # Official image tag `5.4.5-php8.3-apache`. The flavor is treated as an
 # opaque discriminator: tags are only considered upgrade candidates for


### PR DESCRIPTION
Potential fix for [https://github.com/infinito-nexus/core/security/code-scanning/280](https://github.com/infinito-nexus/core/security/code-scanning/280)

To fix this cleanly without changing functionality, remove the unused global constant definition of `_SEMVER_RE` from `utils/docker/version_updater.py`.

Best single fix:
- In `utils/docker/version_updater.py`, delete the line:
  - `_SEMVER_RE = re.compile(rf"^{_SEMVER_CORE}$")`
- No import changes are needed, because `re` remains used by other regex constants (`_VERSIONED_TAG_RE`, `_KEY_RE`, `_VERSION_VALUE_RE`).
- No method or call-site changes are required.

This preserves behavior since no shown logic depends on `_SEMVER_RE`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
