### PR TITLE
fix(sso-proxy): trust self-signed CA for OIDC provider connection

### DIFF
--- a/roles/web-app-keycloak/templates/sso_proxy/oauth2-proxy-keycloak.cfg.j2
+++ b/roles/web-app-keycloak/templates/sso_proxy/oauth2-proxy-keycloak.cfg.j2
@@ -12,6 +12,9 @@ redirect_url            =   "{{ lookup('tls', sso_proxy_application_id, 'protoco
 oidc_issuer_url         =   "{{ OIDC.CLIENT.ISSUER_URL }}"
 provider                =   "oidc"
 provider_display_name   =   "{{ OIDC.BUTTON_TEXT }}"
+{% if (TLS_MODE | lower) == 'self_signed' %}
+provider_ca_file        =   "/tmp/infinito/ca/root-ca.crt"
+{% endif %}
 
 {% set allowed_groups_raw = lookup('sso', sso_proxy_application_id, 'oauth2_allowed_groups') %}
 {% if allowed_groups_raw %}


### PR DESCRIPTION
## Problem

oauth2-proxy (`quay.io/oauth2-proxy/oauth2-proxy`) is a distroless image — it has no `/bin/sh`. 

The platform's `compose_ca.py` correctly injects the CA cert mount and env vars (`SSL_CERT_FILE` etc.) into every container, but only applies the `with-ca-trust.sh` wrapper entrypoint when the image has `/bin/sh`. Since the wrapper is skipped for distroless images, and Go binaries ignore `SSL_CERT_FILE` (using the system cert pool only), oauth2-proxy fails OIDC discovery with `x509: certificate signed by unknown authority` on self-signed TLS setups.

This causes nginx to fall through directly to the upstream app, bypassing SSO entirely. Every `flavor: oauth2` role is affected in CI — discovered while debugging PR #225 (web-app-pihole).

## Fix

oauth2-proxy's `--provider-ca-file` option explicitly loads a CA cert for the OIDC provider connection, bypassing the system cert pool. The platform already bind-mounts the CA cert at `/tmp/infinito/ca/root-ca.crt` in every container (hardcoded in `compose_ca.py`).

The condition guards against production deployments (`letsencrypt`) where no self-signed CA exists.

## Related

Discovered via PR #225 (web-app-pihole).